### PR TITLE
fix: Add missing mock routes for WineGrapes

### DIFF
--- a/apps/web/e2e/mock-server/defaults.ts
+++ b/apps/web/e2e/mock-server/defaults.ts
@@ -80,4 +80,8 @@ export const defaultState: MockState = {
       banReason: null,
     },
   ],
+  wineGrapes: [
+    { wineId: 1, grapeId: 1 },
+    { wineId: 2, grapeId: 2 },
+  ],
 };

--- a/apps/web/e2e/mock-server/index.ts
+++ b/apps/web/e2e/mock-server/index.ts
@@ -43,6 +43,7 @@ export type MockState = {
   locations: any[];
   settings: any[];
   users: any[];
+  wineGrapes: any[];
 };
 
 let server: ServerType | null = null;
@@ -83,6 +84,9 @@ export async function startMockServer(port: number): Promise<ServerType> {
   });
 
   // Register all domain routes
+  // User routes must be registered before auth routes because auth has a
+  // catch-all /api/auth/* that would intercept /api/auth/admin/* endpoints
+  registerUserRoutes(app, state);
   registerAuthRoutes(app, state);
   registerWineRoutes(app, state);
   registerBottleRoutes(app, state);
@@ -94,7 +98,6 @@ export async function startMockServer(port: number): Promise<ServerType> {
   registerStorageRoutes(app, state);
   registerLocationRoutes(app, state);
   registerSettingsRoutes(app, state);
-  registerUserRoutes(app, state);
   registerWinegrapeRoutes(app, state);
 
   return new Promise((resolve) => {

--- a/apps/web/e2e/mock-server/routes/winegrapes.ts
+++ b/apps/web/e2e/mock-server/routes/winegrapes.ts
@@ -1,15 +1,28 @@
 import type { Hono } from "hono";
 import type { MockState } from "../index";
 
-export function registerWinegrapeRoutes(app: Hono, _state: MockState) {
-  app.get("/api/winegrape", (c) => c.json([]));
+export function registerWinegrapeRoutes(app: Hono, state: MockState) {
+  app.get("/api/winegrape", (c) => c.json(state.wineGrapes));
+
+  app.get("/api/winegrape/wine/:wineId", (c) => {
+    const wineId = Number(c.req.param("wineId"));
+    const grapes = state.wineGrapes.filter((wg) => wg.wineId === wineId);
+    return c.json(grapes);
+  });
 
   app.post("/api/winegrape", async (c) => {
     const body = await c.req.json();
-    return c.json({ wineId: body.wineId, grapeId: body.grapeId }, 201);
+    const wineGrape = { wineId: body.wineId, grapeId: body.grapeId };
+    state.wineGrapes.push(wineGrape);
+    return c.json(wineGrape, 201);
   });
 
   app.delete("/api/winegrape/:wineId/:grapeId", (c) => {
+    const wineId = Number(c.req.param("wineId"));
+    const grapeId = Number(c.req.param("grapeId"));
+    state.wineGrapes = state.wineGrapes.filter(
+      (wg) => !(wg.wineId === wineId && wg.grapeId === grapeId),
+    );
     return c.json(true);
   });
 }


### PR DESCRIPTION
## Summary

The E2E test mock server is missing some routes for WineGrapes

## Changes

- Add missing routes
- Add appropriate mock data
- Fix bug with user routes being registered in incorrect order

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [ ] Docs / config only

## Areas affected

- [ ] Backend
- [x] Web application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->
