### PR TITLE
fix: Add missing mock routes for DetailRow

### DIFF
--- a/apps/web/e2e/mock-server/routes/bottles.ts
+++ b/apps/web/e2e/mock-server/routes/bottles.ts
@@ -8,6 +8,21 @@ export function registerBottleRoutes(app: Hono, state: MockState) {
     return c.json(state.bottles);
   });
 
+  app.get("/api/bottle/vintage/:vintageId/counts", (c) => {
+    const vintageId = Number(c.req.param("vintageId"));
+    const bottles = state.bottles.filter((b) => b.vintageId === vintageId);
+    const counts = new Map<string, number>();
+    for (const b of bottles) {
+      counts.set(b.status, (counts.get(b.status) || 0) + 1);
+    }
+    return c.json(
+      Array.from(counts.entries()).map(([status, count]) => ({
+        status,
+        count,
+      })),
+    );
+  });
+
   app.get("/api/bottle/:id", (c) => {
     const id = Number(c.req.param("id"));
     const bottle = state.bottles.find((b) => b.id === id);

--- a/apps/web/e2e/mock-server/routes/vintages.ts
+++ b/apps/web/e2e/mock-server/routes/vintages.ts
@@ -8,6 +8,12 @@ export function registerVintageRoutes(app: Hono, state: MockState) {
     return c.json(state.vintages);
   });
 
+  app.get("/api/vintage/wine/:wineId", (c) => {
+    const wineId = Number(c.req.param("wineId"));
+    const vintages = state.vintages.filter((v) => v.wineId === wineId);
+    return c.json(vintages);
+  });
+
   app.get("/api/vintage/:id", (c) => {
     const id = Number(c.req.param("id"));
     const vintage = state.vintages.find((v) => v.id === id);


### PR DESCRIPTION
## Summary

The E2E test mock server is missing some routes that are necessary to display a DetailRow

## Changes

- Add missing routes

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [ ] Docs / config only

## Areas affected

- [ ] Backend
- [x] Web application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->
