### PR TITLE
fix: Missing mock server healthcheck endpoint

### DIFF
--- a/packages/mock-server/src/index.ts
+++ b/packages/mock-server/src/index.ts
@@ -61,6 +61,10 @@ export async function startMockServer(port: number): Promise<ServerType> {
   const app = new Hono();
 
   // Control endpoints for test setup
+  app.get("/__test/healthcheck", (c) => {
+    return c.json({ ok: true });
+  });
+
   app.post("/__test/set-session", async (c) => {
     state.session = await c.req.json();
     return c.json({ ok: true });


### PR DESCRIPTION
## Summary

New mobile docs screenshot taker needs a healthcheck endpoint that is currently missing

## Changes

- Add missing endpoint to mock server

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [ ] Docs / config only

## Areas affected

- [ ] Backend
- [ ] Web application
- [x] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->
