### PR TITLE
fix: Incorrect icon colour in bottle list view

### DIFF
--- a/apps/web/components/bottles/BottleSizeIcon.tsx
+++ b/apps/web/components/bottles/BottleSizeIcon.tsx
@@ -1,7 +1,7 @@
 import { BottleWine } from "lucide-react";
 import type { BottleSize, WineType } from "@cellarboss/validators/constants";
 import { BOTTLE_SIZES } from "@/lib/constants/bottle-sizes";
-import { WINE_TYPE_COLORS } from "@/lib/constants/wine-colouring";
+import { WINE_TYPE_TEXT_COLORS } from "@/lib/constants/wine-colouring";
 import { formatBottleSize } from "@/lib/functions/format";
 import {
   Tooltip,
@@ -17,7 +17,7 @@ export function BottleSizeIcon({
   wineType: WineType;
 }) {
   const iconSize = BOTTLE_SIZES[size]?.iconSize ?? 16;
-  const colorClass = WINE_TYPE_COLORS[wineType].replace("bg-", "text-");
+  const colorClass = WINE_TYPE_TEXT_COLORS[wineType];
 
   return (
     <Tooltip>

--- a/apps/web/lib/constants/wine-colouring.ts
+++ b/apps/web/lib/constants/wine-colouring.ts
@@ -11,3 +11,13 @@ export const WINE_TYPE_COLORS: Record<WineType, string> = {
   fortified: "bg-amber-700",
   dessert: "bg-yellow-400",
 };
+
+export const WINE_TYPE_TEXT_COLORS: Record<WineType, string> = {
+  red: "text-red-800",
+  white: "text-amber-200",
+  rose: "text-pink-400",
+  orange: "text-orange-400",
+  sparkling: "text-sky-300",
+  fortified: "text-amber-700",
+  dessert: "text-yellow-400",
+};


### PR DESCRIPTION
## Summary

Fixes web app not showing correct icon colour in bottle list view

## Changes

- Add explicit `WINE_TYPE_TEXT_COLORS` constant rather than inferring, since tailwind wasn't picking it up

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [ ] Docs / config only

## Areas affected

- [ ] Backend
- [x] Web application
- [ ] Android application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

Fixes #231 
