### PR TITLE
fix: Potential for server-side request forgery

### DIFF
--- a/apps/web/lib/api/server.ts
+++ b/apps/web/lib/api/server.ts
@@ -5,11 +5,30 @@ import { webEnv } from "../env";
 import type { ApiResult } from "./types";
 import { processBackendError } from "@cellarboss/common";
 
+function sanitizeApiPath(rawPath: string): string {
+  const path = rawPath.trim();
+
+  // Disallow full URLs or protocol-like strings.
+  if (path.includes("://")) {
+    throw new Error("Invalid API path");
+  }
+
+  // Disallow path traversal segments.
+  if (path.split("/").includes("..")) {
+    throw new Error("Invalid API path");
+  }
+
+  // Ensure path is relative under `/api/` by stripping leading slashes.
+  return path.replace(/^\/+/, "");
+}
+
 export async function makeServerRequest<T>(
   path: string,
   method: "GET" | "POST" | "PUT" | "DELETE",
   body?: string,
 ): Promise<ApiResult<T>> {
+  const safePath = sanitizeApiPath(path);
+
   const headersList = await headers();
   const cookie = headersList.get("cookie");
   const origin = headersList.get("origin");
@@ -26,7 +45,7 @@ export async function makeServerRequest<T>(
   }
 
   try {
-    const res = await fetch(`${webEnv.CELLARBOSS_SERVER}/api/${path}`, {
+    const res = await fetch(`${webEnv.CELLARBOSS_SERVER}/api/${safePath}`, {
       method,
       headers: reqHeaders,
       body,


### PR DESCRIPTION
Potential fix for [https://github.com/CellarBoss/cellarboss/security/code-scanning/15](https://github.com/CellarBoss/cellarboss/security/code-scanning/15)

In general, the fix is to ensure that user-controlled data cannot arbitrarily control the request URL. Since the host is already fixed via `webEnv.CELLARBOSS_SERVER`, the remaining step is to constrain the `path` argument so that it cannot escape the intended `/api/` namespace or include dangerous patterns (like `..`, leading slashes that override the prefix, or full URLs). This should be done inside `makeServerRequest`, since it is the common sink for outgoing backend calls.

The best targeted fix here is to sanitize and normalize `path` just before using it to construct the URL. We can: (1) reject absolute URLs or protocol-like strings (`://`), (2) remove any leading slashes so `path` is always relative under `/api/`, and (3) reject any path containing `..` segments, which could be used for traversal or to target unexpected endpoints. To avoid changing behavior for valid relative paths, we simply normalize them (strip a single or multiple leading `/` characters) and throw an error if they fail validation; the caller will then see a 500-style error from the existing catch block. Implementation-wise, we introduce a small helper `sanitizeApiPath` inside the same file (no new dependencies) and call it at the top of `makeServerRequest` to produce a `safePath` that we use instead of `path` in the `fetch` URL. All changes are confined to `apps/web/lib/api/server.ts` around and above the existing function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
