### PR TITLE
chore: Add minimum necessary permissions to all workflows

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -11,7 +11,10 @@ on:
         description: 'Run test:coverage instead of test and upload coverage artifacts'
         type: boolean
         default: false
-        
+
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: Detect Changes

--- a/.github/workflows/expo-update.yml
+++ b/.github/workflows/expo-update.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 */12 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   expo-update:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,7 @@ on:
       - ready_for_review
 
 permissions:
+  contents: read
   statuses: write
 
 jobs:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,6 +12,7 @@ on:
       - ready_for_review
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,7 +3,10 @@ on:
   schedule:
     - cron: '0 */2 * * *'
   workflow_dispatch:
-  
+
+permissions:
+  contents: read
+
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoketest-android.yml
+++ b/.github/workflows/smoketest-android.yml
@@ -4,6 +4,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke-test-android:
     name: Android Smoke Test


### PR DESCRIPTION
## Summary

Define minimum necessary permissions for all GitHub workflows

## Changes

- Base permissions of `contents: read`, or `write` where necessary

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [x] Docs / config only

## Areas affected

- [ ] Backend
- [ ] Web application
- [ ] Android application
- [x] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->
