### PR TITLE
chore: Use alls-green as converging point for CI checks

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -339,6 +339,16 @@ jobs:
       - validate-mobile-docs
 
     steps:
-      - uses: re-actors/alls-green@release/v1
-        with:
-          jobs: ${{ toJSON(needs) }}
+    - id: skips
+      run: |
+        echo "allowed=$(echo '${{ toJSON(needs) }}' | jq -r '
+        to_entries
+        | map(select(.value.result == "skipped"))
+        | map(.key)
+        | join(",")
+         ')" >> $GITHUB_OUTPUT
+
+    - uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
+        allowed-skips: ${{ steps.skips.outputs.allowed }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -321,3 +321,24 @@ jobs:
 
       - name: Build docs (without screenshots)
         run: pnpm --filter @cellarboss/mobile docs:build
+
+  ci-required:
+    name: Required CI Checks
+    runs-on: ubuntu-latest
+    if: always() && !cancelled()
+    needs:
+      - test-web-functions
+      - test-validators
+      - test-common
+      - test-backend
+      - test-mobile
+      - test-web-e2e
+      - validate-expo
+      - validate-api-docs
+      - validate-web-docs
+      - validate-mobile-docs
+
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary

Use alls-green at the end of CI tests so we can have a single check in branch protection rules. Fixes an issue where skipped matrix tests block auto-merge

## Changes

<!-- List the key changes made. -->

- Add `re-actors/alls-green` to the end of `ci-tests.yml`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [x] Docs / config only

## Areas affected

- [ ] Backend
- [ ] Web application
- [ ] Android application
- [x] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->
