### PR TITLE
fix: Missing 'NV' in Vintage title

### DIFF
--- a/apps/web/components/wine/VintageDisplay.tsx
+++ b/apps/web/components/wine/VintageDisplay.tsx
@@ -16,7 +16,7 @@ export function VintageDisplay({ vintage, wine, winemaker }: Props) {
     <span>
       <Link href={`/wines/${wine.id}`}>{wine.name}</Link>
       &nbsp;
-      <Link href={`/vintages/${vintage.id}`}>{vintage.year}</Link>
+      <Link href={`/vintages/${vintage.id}`}>{vintage.year ?? "NV"}</Link>
       <br />
       <Link
         href={`/winemakers/${winemaker.id}`}


### PR DESCRIPTION
## Summary

#317 discussed whether or not Vintages without an associated year should have 'NV' displayed or not, as the behaviour is inconsistent across applications

## Changes

- Updated web app `VintageDisplay` to show 'NV' where a year doesn't exist

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [ ] Docs / config only

## Areas affected

- [ ] Backend
- [x] Web application
- [ ] Android application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

Closes #317 
