### PR TITLE
fix: Version alerting not functioning

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -29,6 +29,7 @@
     "@tanstack/react-query": "catalog:",
     "date-fns": "4.1.0",
     "expo": "55.0.15",
+    "expo-application": "55.0.14",
     "expo-constants": "55.0.14",
     "expo-haptics": "55.0.14",
     "expo-image": "55.0.8",

--- a/apps/mobile/src/app/(app)/(tabs)/(more)/more.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(more)/more.tsx
@@ -10,6 +10,7 @@ import { useApiQuery } from "@/hooks/use-api-query";
 import { api } from "@/lib/api/client";
 import { getApiBaseUrl } from "@/lib/api/base-url";
 import type { ThemePreference } from "@/lib/auth/secure-store";
+import * as Application from "expo-application";
 
 const themeLabels: Record<ThemePreference, string> = {
   light: "Light",
@@ -185,25 +186,38 @@ export default function MoreScreen() {
           </Dialog>
         </Portal>
 
-        <Divider />
         {apiBaseUrl && (
-          <List.Section>
-            <List.Subheader>CellarBoss Server</List.Subheader>
+          <>
+            <Divider />
+            <List.Section>
+              <List.Subheader>CellarBoss Server</List.Subheader>
 
-            <List.Item
-              testID="menu-server"
-              title="URL"
-              description={apiBaseUrl}
-              left={(props) => <List.Icon {...props} icon="server-network" />}
-            />
-            <List.Item
-              testID="menu-server-version"
-              title="Version"
-              description={versionQuery.data?.version}
-              left={(props) => <List.Icon {...props} icon="tag-outline" />}
-            />
-          </List.Section>
+              <List.Item
+                testID="menu-server"
+                title="URL"
+                description={apiBaseUrl}
+                left={(props) => <List.Icon {...props} icon="server-network" />}
+              />
+              <List.Item
+                testID="menu-server-version"
+                title="Version"
+                description={versionQuery.data?.version}
+                left={(props) => <List.Icon {...props} icon="tag-outline" />}
+              />
+            </List.Section>
+          </>
         )}
+
+        <Divider />
+        <List.Section>
+          <List.Subheader>CellarBoss Mobile</List.Subheader>
+          <List.Item
+            testID="menu-app-version"
+            title="Application Version"
+            description={Application.nativeApplicationVersion ?? "Unknown"}
+            left={(props) => <List.Icon {...props} icon="wrench-outline" />}
+          />
+        </List.Section>
       </ScrollView>
     </SafeAreaView>
   );

--- a/apps/mobile/src/app/(app)/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/_layout.tsx
@@ -7,7 +7,6 @@ import {
 import { Tabs } from "expo-router";
 import { Icon } from "react-native-paper";
 import { useAppTheme } from "@/hooks/use-app-theme";
-import { VersionMismatchBanner } from "@/components/VersionMismatchBanner";
 
 // Tab folders are groups like `(cellar)`, `(wines)`, so detail routes can be
 // shared across every tab via the `(dashboard,cellar,wines,storages,more)/`
@@ -46,76 +45,73 @@ export default function TabLayout() {
   const theme = useAppTheme();
 
   return (
-    <>
-      <VersionMismatchBanner />
-      <Tabs
-        backBehavior="history"
-        screenOptions={{
-          headerShown: false,
-          tabBarActiveTintColor: theme.colors.primary,
-          tabBarActiveBackgroundColor: theme.colors.surfaceVariant,
-          tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
-          tabBarStyle: {
-            borderTopColor: theme.colors.outlineVariant,
-          },
+    <Tabs
+      backBehavior="history"
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: theme.colors.primary,
+        tabBarActiveBackgroundColor: theme.colors.surfaceVariant,
+        tabBarInactiveTintColor: theme.colors.onSurfaceVariant,
+        tabBarStyle: {
+          borderTopColor: theme.colors.outlineVariant,
+        },
+      }}
+    >
+      <Tabs.Screen
+        name="(dashboard)"
+        listeners={resetTabOnPress}
+        options={{
+          title: "Dashboard",
+          tabBarButtonTestID: "dashboard-tab",
+          tabBarIcon: ({ color, size }) => (
+            <Icon source="view-dashboard-outline" size={size} color={color} />
+          ),
         }}
-      >
-        <Tabs.Screen
-          name="(dashboard)"
-          listeners={resetTabOnPress}
-          options={{
-            title: "Dashboard",
-            tabBarButtonTestID: "dashboard-tab",
-            tabBarIcon: ({ color, size }) => (
-              <Icon source="view-dashboard-outline" size={size} color={color} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="(cellar)"
-          listeners={resetTabOnPress}
-          options={{
-            title: "Cellar",
-            tabBarButtonTestID: "cellar-tab",
-            tabBarIcon: ({ color, size }) => (
-              <Icon source="bottle-wine-outline" size={size} color={color} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="(wines)"
-          listeners={resetTabOnPress}
-          options={{
-            title: "Wines",
-            tabBarButtonTestID: "wines-tab",
-            tabBarIcon: ({ color, size }) => (
-              <Icon source="glass-wine" size={size} color={color} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="(storages)"
-          listeners={resetTabOnPress}
-          options={{
-            title: "Storages",
-            tabBarButtonTestID: "storages-tab",
-            tabBarIcon: ({ color, size }) => (
-              <Icon source="warehouse" size={size} color={color} />
-            ),
-          }}
-        />
-        <Tabs.Screen
-          name="(more)"
-          listeners={resetTabOnPress}
-          options={{
-            title: "More",
-            tabBarButtonTestID: "more-tab",
-            tabBarIcon: ({ color, size }) => (
-              <Icon source="dots-horizontal" size={size} color={color} />
-            ),
-          }}
-        />
-      </Tabs>
-    </>
+      />
+      <Tabs.Screen
+        name="(cellar)"
+        listeners={resetTabOnPress}
+        options={{
+          title: "Cellar",
+          tabBarButtonTestID: "cellar-tab",
+          tabBarIcon: ({ color, size }) => (
+            <Icon source="bottle-wine-outline" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="(wines)"
+        listeners={resetTabOnPress}
+        options={{
+          title: "Wines",
+          tabBarButtonTestID: "wines-tab",
+          tabBarIcon: ({ color, size }) => (
+            <Icon source="glass-wine" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="(storages)"
+        listeners={resetTabOnPress}
+        options={{
+          title: "Storages",
+          tabBarButtonTestID: "storages-tab",
+          tabBarIcon: ({ color, size }) => (
+            <Icon source="warehouse" size={size} color={color} />
+          ),
+        }}
+      />
+      <Tabs.Screen
+        name="(more)"
+        listeners={resetTabOnPress}
+        options={{
+          title: "More",
+          tabBarButtonTestID: "more-tab",
+          tabBarIcon: ({ color, size }) => (
+            <Icon source="dots-horizontal" size={size} color={color} />
+          ),
+        }}
+      />
+    </Tabs>
   );
 }

--- a/apps/mobile/src/app/(app)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/_layout.tsx
@@ -1,5 +1,7 @@
+import { View } from "react-native";
 import { Redirect, Stack } from "expo-router";
 import { useAuth } from "@/contexts/auth-context";
+import { VersionMismatchBanner } from "@/components/VersionMismatchBanner";
 
 export default function AppLayout() {
   const auth = useAuth();
@@ -12,5 +14,12 @@ export default function AppLayout() {
     return <Redirect href="/(auth)/login" />;
   }
 
-  return <Stack screenOptions={{ headerShown: false }} />;
+  return (
+    <View style={{ flex: 1 }}>
+      <VersionMismatchBanner />
+      <View style={{ flex: 1 }}>
+        <Stack screenOptions={{ headerShown: false }} />
+      </View>
+    </View>
+  );
 }

--- a/apps/mobile/src/components/VersionMismatchBanner.tsx
+++ b/apps/mobile/src/components/VersionMismatchBanner.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { Banner } from "react-native-paper";
-import Constants from "expo-constants";
+import * as Application from "expo-application";
 import { useVersionMismatch } from "@cellarboss/common";
 import { api } from "@/lib/api/client";
 
-const appVersion = Constants.expoConfig?.version ?? "0.0.0";
+const appVersion = Application.nativeApplicationVersion ?? "0.0.0";
 
 export function VersionMismatchBanner() {
   const [dismissed, setDismissed] = useState(false);

--- a/apps/mobile/src/components/VersionMismatchBanner.tsx
+++ b/apps/mobile/src/components/VersionMismatchBanner.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { Banner } from "react-native-paper";
 import * as Application from "expo-application";
 import { useVersionMismatch } from "@cellarboss/common";
@@ -13,14 +14,18 @@ export function VersionMismatchBanner() {
     queryFn: () => api.version.get(),
   });
 
+  if (!isMismatch || dismissed) return null;
+
   return (
-    <Banner
-      visible={isMismatch && !dismissed}
-      icon="alert"
-      actions={[{ label: "Dismiss", onPress: () => setDismissed(true) }]}
-    >
-      Your app (v{appVersion}) is newer than the server (v{backendVersion}).
-      Some features may not work until the server is updated.
-    </Banner>
+    <SafeAreaView edges={["top"]}>
+      <Banner
+        visible
+        icon="alert"
+        actions={[{ label: "Dismiss", onPress: () => setDismissed(true) }]}
+      >
+        Your app (v{appVersion}) is newer than the server (v{backendVersion}).
+        Some features may not work until the server is updated.
+      </Banner>
+    </SafeAreaView>
   );
 }

--- a/apps/web/components/page/VersionMismatchBanner.tsx
+++ b/apps/web/components/page/VersionMismatchBanner.tsx
@@ -27,7 +27,7 @@ export function VersionMismatchBanner() {
     >
       <AlertTriangle className="h-5 w-5 shrink-0" />
       <p className="text-sm flex-1">
-        The application version (v{frontendVersion}) is newer than the server (v
+        The application version ({frontendVersion}) is newer than the server (
         {backendVersion}). Some features may not work correctly until the server
         is updated.
       </p>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       expo:
         specifier: 55.0.15
         version: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-application:
+        specifier: 55.0.14
+        version: 55.0.14(expo@55.0.15)
       expo-constants:
         specifier: 55.0.14
         version: 55.0.14(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(typescript@5.9.3)
@@ -5199,6 +5202,11 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  expo-application@55.0.14:
+    resolution: {integrity: sha512-NgqDIt3eCf4aVLp1L6AcEanCYoyJeuBsGrgGSzOIvxAsOvp5X3SYKW3ROgpKUnLQEKMWlzwETpjsUGszcqkk8g==}
+    peerDependencies:
+      expo: '*'
 
   expo-asset@55.0.15:
     resolution: {integrity: sha512-d3FIpHJ6ZngYXxRItYWBGT5H8Wkk7/l4fMe8Mmd2xDyKrO0/CM7c8r/J5M71D+BJr5P3My8wertGYZXHSiZYxQ==}
@@ -13448,7 +13456,7 @@ snapshots:
       eslint: 10.2.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@10.2.0(jiti@2.6.1))
@@ -13481,7 +13489,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -13496,7 +13504,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -13682,6 +13690,10 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  expo-application@55.0.14(expo@55.0.15):
+    dependencies:
+      expo: 55.0.15(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.9)(expo-router@55.0.12)(react-dom@19.2.0(react@19.2.0))(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-asset@55.0.15(expo@55.0.15)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

Version alerting was incorrect on web, and not displaying at all on mobile

## Changes

- Change method of fetching version in mobile
- Move mobile alert banner to more appropriate part of application structure
- Remove double "v" at start of alert banner on web

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [ ] Docs / config only

## Areas affected

- [ ] Backend
- [x] Web application
- [x] Android application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->
