### PR TITLE
feat: Include ordered bottles in drinking window timeline

### DIFF
--- a/apps/web/components/dashboard/DrinkingWindowTimeline.tsx
+++ b/apps/web/components/dashboard/DrinkingWindowTimeline.tsx
@@ -104,7 +104,11 @@ export function DrinkingWindowTimeline({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className="h-[250px] w-full">
+        <ChartContainer
+          config={chartConfig}
+          className="h-[250px] w-full"
+          data-testid="drinking-window-timeline-chart"
+        >
           <BarChart data={chartData} accessibilityLayer>
             <CartesianGrid vertical={false} />
             <XAxis dataKey="year" tickLine={false} axisLine={false} />

--- a/apps/web/components/dashboard/DrinkingWindowTimeline.tsx
+++ b/apps/web/components/dashboard/DrinkingWindowTimeline.tsx
@@ -32,6 +32,12 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
+const timelineBottleStatuses = new Set<Bottle["status"]>([
+  "stored",
+  "ordered",
+  "in-primeur",
+]);
+
 interface DrinkingWindowTimelineProps {
   bottles: Bottle[];
   vintages: Vintage[];
@@ -43,7 +49,9 @@ export function DrinkingWindowTimeline({
 }: DrinkingWindowTimelineProps) {
   const chartData = useMemo(() => {
     const vintageMap = new Map(vintages.map((v) => [v.id, v]));
-    const storedBottles = bottles.filter((b) => b.status === "stored");
+    const timelineBottles = bottles.filter((b) =>
+      timelineBottleStatuses.has(b.status),
+    );
     const currentYear = new Date().getFullYear();
 
     const years = Array.from({ length: 10 }, (_, i) => currentYear + i);
@@ -53,7 +61,7 @@ export function DrinkingWindowTimeline({
       let tooYoung = 0;
       let pastPeak = 0;
 
-      for (const bottle of storedBottles) {
+      for (const bottle of timelineBottles) {
         const vintage = vintageMap.get(bottle.vintageId);
         if (!vintage) continue;
         if (vintage.drinkFrom === null && vintage.drinkUntil === null) continue;

--- a/apps/web/e2e/tests/dashboard.spec.ts
+++ b/apps/web/e2e/tests/dashboard.spec.ts
@@ -206,42 +206,35 @@ test.describe("Dashboard page", () => {
     await expect(page.getByText("Drinking Window Timeline")).toBeVisible();
   });
 
-  test("includes ordered and in-primeur bottles in drinking window timeline", async ({
-    adminContext,
-  }) => {
-    const state = buildDashboardState();
-    state.bottles = [
-      {
-        id: 1,
-        vintageId: 1,
-        purchaseDate: today,
-        purchasePrice: 250.0,
-        storageId: null,
-        status: "ordered",
-        size: "standard",
-      },
-      {
-        id: 2,
-        vintageId: 2,
-        purchaseDate: today,
-        purchasePrice: 85.0,
-        storageId: null,
-        status: "in-primeur",
-        size: "standard",
-      },
-    ];
-    await setState(state);
+  for (const status of ["ordered", "in-primeur"] as const) {
+    test(`includes ${status} bottles in drinking window timeline`, async ({
+      adminContext,
+    }) => {
+      const state = buildDashboardState();
+      state.bottles = [
+        {
+          id: 1,
+          vintageId: 1,
+          purchaseDate: today,
+          purchasePrice: 250.0,
+          storageId: null,
+          status,
+          size: "standard",
+        },
+      ];
+      await setState(state);
 
-    const page = await adminContext.newPage();
-    await page.goto("/");
+      const page = await adminContext.newPage();
+      await page.goto("/");
 
-    await expect(page.getByText("Drinking Window Timeline")).toBeVisible();
-    await expect(
-      page.getByText(
-        "Add drinking windows to your vintages to see this timeline",
-      ),
-    ).toBeHidden();
-  });
+      await expect(page.getByText("Drinking Window Timeline")).toBeVisible();
+      await expect(
+        page.getByText(
+          "Add drinking windows to your vintages to see this timeline",
+        ),
+      ).toBeHidden();
+    });
+  }
 
   test("shows cellar value over time chart", async ({ adminContext }) => {
     const page = await adminContext.newPage();

--- a/apps/web/e2e/tests/dashboard.spec.ts
+++ b/apps/web/e2e/tests/dashboard.spec.ts
@@ -233,6 +233,16 @@ test.describe("Dashboard page", () => {
           "Add drinking windows to your vintages to see this timeline",
         ),
       ).toBeHidden();
+
+      const timelineChart = page.getByTestId("drinking-window-timeline-chart");
+      await expect(timelineChart).toBeVisible();
+      await expect(timelineChart.locator("svg.recharts-surface")).toBeVisible();
+      await expect(
+        timelineChart.getByText(String(currentYear), { exact: true }),
+      ).toBeVisible();
+      await expect(
+        timelineChart.locator(".recharts-bar-rectangle").first(),
+      ).toBeVisible();
     });
   }
 

--- a/apps/web/e2e/tests/dashboard.spec.ts
+++ b/apps/web/e2e/tests/dashboard.spec.ts
@@ -206,6 +206,43 @@ test.describe("Dashboard page", () => {
     await expect(page.getByText("Drinking Window Timeline")).toBeVisible();
   });
 
+  test("includes ordered and in-primeur bottles in drinking window timeline", async ({
+    adminContext,
+  }) => {
+    const state = buildDashboardState();
+    state.bottles = [
+      {
+        id: 1,
+        vintageId: 1,
+        purchaseDate: today,
+        purchasePrice: 250.0,
+        storageId: null,
+        status: "ordered",
+        size: "standard",
+      },
+      {
+        id: 2,
+        vintageId: 2,
+        purchaseDate: today,
+        purchasePrice: 85.0,
+        storageId: null,
+        status: "in-primeur",
+        size: "standard",
+      },
+    ];
+    await setState(state);
+
+    const page = await adminContext.newPage();
+    await page.goto("/");
+
+    await expect(page.getByText("Drinking Window Timeline")).toBeVisible();
+    await expect(
+      page.getByText(
+        "Add drinking windows to your vintages to see this timeline",
+      ),
+    ).toBeHidden();
+  });
+
   test("shows cellar value over time chart", async ({ adminContext }) => {
     const page = await adminContext.newPage();
     await page.goto("/");


### PR DESCRIPTION
## Summary

- Include `stored`, `ordered`, and `in-primeur` bottles in the web dashboard drinking window timeline.
- Add a dashboard e2e regression test covering ordered and in-primeur bottles with drinking windows.

Closes #541.

## Validation

- `pnpm exec prettier --check apps/web/components/dashboard/DrinkingWindowTimeline.tsx apps/web/e2e/tests/dashboard.spec.ts`
- `pnpm --filter @cellarboss/web test`
- `CELLARBOSS_SERVER=http://localhost:5173 BETTER_AUTH_SECRET=e2e-test-secret-placeholder BETTER_AUTH_URL=http://localhost:5173 pnpm --filter @cellarboss/web build`
- Targeted Playwright regression passed on alternate local port 3400 using a temporary config, to avoid an existing process on port 3000.

Note: `pnpm --filter @cellarboss/web lint` currently crashes before linting this diff with `eslint-plugin-react` under ESLint 10 (`react/display-name`: `contextOrFilename.getFilename is not a function`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The drinking-window timeline now includes additional bottle statuses (such as ordered and in‑primeur), expanding the 10‑year chart coverage.

* **Tests**
  * Added end-to-end tests to verify the dashboard timeline renders correctly for those statuses, shows chart elements (SVG surface, current year label, bars) and hides the empty-state message when data is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->