### PR TITLE
feat: Include additional bottles in drinking window timeline

### DIFF
--- a/apps/mobile/src/components/dashboard/DrinkingWindowTimeline.tsx
+++ b/apps/mobile/src/components/dashboard/DrinkingWindowTimeline.tsx
@@ -8,6 +8,12 @@ type DrinkingWindowTimelineProps = {
   vintages: Vintage[];
 };
 
+const timelineBottleStatuses = new Set<Bottle["status"]>([
+  "stored",
+  "ordered",
+  "in-primeur",
+]);
+
 const READY_COLOR = "#2E8B57";
 const TOO_YOUNG_COLOR = "#BDB76B";
 const PAST_PEAK_COLOR = "#CD5C5C";
@@ -19,7 +25,9 @@ export function DrinkingWindowTimeline({
   const theme = useAppTheme();
   const currentYear = new Date().getFullYear();
   const vintageMap = new Map(vintages.map((v) => [v.id, v]));
-  const storedBottles = bottles.filter((b) => b.status === "stored");
+  const storedBottles = bottles.filter((b) =>
+    timelineBottleStatuses.has(b.status),
+  );
 
   const years = Array.from({ length: 10 }, (_, i) => currentYear + i);
 


### PR DESCRIPTION
## Summary

Similar to #542, but implemented on mobile as well

## Changes

- Included `ordered` and `in-primeur` bottles within timeline component on dashboard

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [ ] Docs / config only

## Areas affected

- [ ] Backend
- [ ] Web application
- [x] Android application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

Related to #542 and #541 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the drinking window timeline dashboard to include ordered and pre-release bottles when calculating collection readiness status. The annual "Ready/Too Young/Past Peak" analysis now provides a more comprehensive view of your wine collection by incorporating these additional bottle statuses alongside stored bottles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->