### PR TITLE
fix: Date picker selecting incorrect date

### DIFF
--- a/apps/web/components/cards/DateField.tsx
+++ b/apps/web/components/cards/DateField.tsx
@@ -20,8 +20,8 @@ export function DateField({ field, editable }: DateFieldProps) {
   const [open, setOpen] = useState(false);
   const value: string = field.state.value ?? "";
 
-  // Parse "YYYY-MM-DD" string to Date for the calendar (avoid timezone shift)
-  const dateValue = value ? new Date(value + "T00:00:00Z") : undefined;
+  // Parse "YYYY-MM-DD" string to Date for the calendar using local midnight to avoid timezone shift
+  const dateValue = value ? new Date(value + "T00:00:00") : undefined;
 
   const displayText = dateValue
     ? dateValue.toLocaleDateString("en-GB", {
@@ -60,8 +60,10 @@ export function DateField({ field, editable }: DateFieldProps) {
           selected={dateValue}
           onSelect={(date) => {
             if (date) {
-              const iso = date.toISOString().split("T")[0];
-              field.handleChange(iso);
+              const yyyy = date.getFullYear();
+              const mm = String(date.getMonth() + 1).padStart(2, "0");
+              const dd = String(date.getDate()).padStart(2, "0");
+              field.handleChange(`${yyyy}-${mm}-${dd}`);
             }
             setOpen(false);
           }}


### PR DESCRIPTION
## Summary

Fixes #537 where incorrect date could be selected from `date-picker` component due to timezone issues

## Changes

<!-- List the key changes made. -->

- Use local midnight when selecting dates

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [ ] Docs / config only

## Areas affected

- [ ] Backend
- [x] Web application
- [ ] Android application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

Fixes #537 

<!-- Link any related issues: "Closes #123" or "Related to #456" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Date field now correctly uses local time for date parsing and formatting, ensuring dates are handled consistently across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->