### PR TITLE
fix: Use local date-only values for bottle dates

### DIFF
--- a/apps/web/app/bottles/new/page.tsx
+++ b/apps/web/app/bottles/new/page.tsx
@@ -8,6 +8,7 @@ import { bottleCreateFields, type BottleFormData } from "@/lib/fields/bottles";
 import { createBottle } from "@/lib/api/bottles";
 import type { ApiResult } from "@/lib/api/types";
 import { PageHeader } from "@/components/page/PageHeader";
+import { formatDateOnly } from "@/lib/functions/date";
 
 async function handleCreate(
   data: BottleFormData,
@@ -34,7 +35,7 @@ async function handleCreate(
 function NewBottleForm() {
   const searchParams = useSearchParams();
   const vintageId = searchParams.get("vintageId");
-  const today = new Date().toISOString().split("T")[0];
+  const today = formatDateOnly(new Date());
 
   const defaultData: BottleFormData = {
     id: 0,

--- a/apps/web/components/cards/DateField.tsx
+++ b/apps/web/components/cards/DateField.tsx
@@ -10,6 +10,7 @@ import {
 import { Calendar } from "@/components/ui/calendar";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { formatDateOnly, parseDateOnly } from "@/lib/functions/date";
 
 type DateFieldProps = {
   field: any;
@@ -20,8 +21,7 @@ export function DateField({ field, editable }: DateFieldProps) {
   const [open, setOpen] = useState(false);
   const value: string = field.state.value ?? "";
 
-  // Parse "YYYY-MM-DD" string to Date for the calendar using local midnight to avoid timezone shift
-  const dateValue = value ? new Date(value + "T00:00:00") : undefined;
+  const dateValue = value ? parseDateOnly(value) : undefined;
 
   const displayText = dateValue
     ? dateValue.toLocaleDateString("en-GB", {
@@ -60,10 +60,7 @@ export function DateField({ field, editable }: DateFieldProps) {
           selected={dateValue}
           onSelect={(date) => {
             if (date) {
-              const yyyy = date.getFullYear();
-              const mm = String(date.getMonth() + 1).padStart(2, "0");
-              const dd = String(date.getDate()).padStart(2, "0");
-              field.handleChange(`${yyyy}-${mm}-${dd}`);
+              field.handleChange(formatDateOnly(date));
             }
             setOpen(false);
           }}

--- a/apps/web/e2e/tests/bottles.spec.ts
+++ b/apps/web/e2e/tests/bottles.spec.ts
@@ -82,6 +82,35 @@ test.describe("Bottles page", () => {
     await expect(page).toHaveURL("/bottles/new");
   });
 
+  test("keeps selected purchase date from date picker", async ({
+    adminContext,
+  }) => {
+    const page = await adminContext.newPage();
+    await page.goto("/bottles/new");
+
+    const selectedDate = await page.evaluate(() => {
+      const date = new Date();
+
+      return {
+        daySelector: date.toLocaleDateString(),
+        label: date.toLocaleDateString("en-GB", {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+        }),
+      };
+    });
+
+    await page.getByRole("button", { name: selectedDate.label }).click();
+    await page
+      .locator(`button[data-day="${selectedDate.daySelector}"]`)
+      .click();
+
+    await expect(
+      page.getByRole("button", { name: selectedDate.label }),
+    ).toBeVisible();
+  });
+
   test("shows purchase price formatted with currency", async ({
     adminContext,
   }) => {

--- a/apps/web/lib/functions/__tests__/date.test.ts
+++ b/apps/web/lib/functions/__tests__/date.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { formatDateOnly, parseDateOnly } from "../date";
+
+describe("parseDateOnly", () => {
+  it("parses date-only strings as local calendar dates", () => {
+    const date = parseDateOnly("2026-06-04");
+
+    expect(date).toBeInstanceOf(Date);
+    expect(date?.getFullYear()).toBe(2026);
+    expect(date?.getMonth()).toBe(5);
+    expect(date?.getDate()).toBe(4);
+  });
+
+  it("rejects invalid date-only strings", () => {
+    expect(parseDateOnly("2026-02-31")).toBeUndefined();
+    expect(parseDateOnly("2026-6-4")).toBeUndefined();
+    expect(parseDateOnly("not-a-date")).toBeUndefined();
+  });
+});
+
+describe("formatDateOnly", () => {
+  it("formats local calendar dates without UTC conversion", () => {
+    const date = new Date(2026, 5, 4);
+
+    expect(formatDateOnly(date)).toBe("2026-06-04");
+  });
+
+  it("pads single-digit months and days", () => {
+    const date = new Date(2026, 0, 5);
+
+    expect(formatDateOnly(date)).toBe("2026-01-05");
+  });
+});

--- a/apps/web/lib/functions/date.ts
+++ b/apps/web/lib/functions/date.ts
@@ -1,0 +1,31 @@
+/**
+ * Parses a YYYY-MM-DD value as a local calendar date.
+ */
+export function parseDateOnly(value: string): Date | undefined {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return undefined;
+
+  const [, year, month, day] = match;
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
+
+  if (
+    date.getFullYear() !== Number(year) ||
+    date.getMonth() !== Number(month) - 1 ||
+    date.getDate() !== Number(day)
+  ) {
+    return undefined;
+  }
+
+  return date;
+}
+
+/**
+ * Formats a Date as a local YYYY-MM-DD calendar value.
+ */
+export function formatDateOnly(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## Summary
- Move date-only parsing and formatting into shared helpers that use local calendar dates
- Use the helper for the New Bottle default purchase date so it does not drift through UTC conversion
- Add unit and E2E regression coverage for the date-only behavior

## Related
Follow-up to #547 / #537.

## Verification
- `pnpm exec prettier --check apps/web/app/bottles/new/page.tsx apps/web/components/cards/DateField.tsx apps/web/lib/functions/date.ts apps/web/lib/functions/__tests__/date.test.ts apps/web/e2e/tests/bottles.spec.ts`
- `pnpm --filter @cellarboss/web test`
- `pnpm --filter @cellarboss/web lint` (0 errors, 67 existing warnings)
- Targeted Playwright regression test for `keeps selected purchase date from date picker` against port 3400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for date parsing/formatting utilities.
  * Added an end-to-end test verifying the date picker preserves selected purchase dates in forms.

* **Refactor**
  * Standardised date handling across the app using shared parsing/formatting utilities, including consistent defaulting for the New Bottle form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->