### PR TITLE
feat: Move mobile list controls inline

### DIFF
--- a/apps/mobile/src/__tests__/components/DataList.test.tsx
+++ b/apps/mobile/src/__tests__/components/DataList.test.tsx
@@ -80,7 +80,8 @@ describe("DataList", () => {
     expect(screen.getByText("Burgundy")).toBeTruthy();
     expect(screen.getByText("Barossa Valley")).toBeTruthy();
     expect(screen.queryByText("Bordeaux")).toBeNull();
-    expect(screen.getByText("Filters (1)")).toBeTruthy();
+    expect(screen.getByLabelText("Filters, 1 active")).toBeTruthy();
+    expect(screen.getByTestId("filter-active-count")).toBeTruthy();
   });
 
   it("shows empty state when no data", () => {

--- a/apps/mobile/src/__tests__/components/FilterSheet.test.tsx
+++ b/apps/mobile/src/__tests__/components/FilterSheet.test.tsx
@@ -47,17 +47,18 @@ function renderFilterSheet(
 describe("FilterSheet", () => {
   it("shows Filters button", () => {
     renderFilterSheet();
-    expect(screen.getByText("Filters")).toBeTruthy();
+    expect(screen.getByLabelText("Filters")).toBeTruthy();
   });
 
   it("shows active count when filters are selected", () => {
     renderFilterSheet({ values: { type: ["red"], status: [] } });
-    expect(screen.getByText("Filters (1)")).toBeTruthy();
+    expect(screen.getByLabelText("Filters, 1 active")).toBeTruthy();
+    expect(screen.getByTestId("filter-active-count")).toBeTruthy();
   });
 
   it("opens modal showing filter options", () => {
     renderFilterSheet();
-    fireEvent.press(screen.getByText("Filters"));
+    fireEvent.press(screen.getByLabelText("Filters"));
 
     expect(screen.getByText("Wine Type")).toBeTruthy();
     expect(screen.getByText("Red")).toBeTruthy();
@@ -69,7 +70,7 @@ describe("FilterSheet", () => {
   it("Apply button calls onChange with selections", () => {
     const { onChange } = renderFilterSheet();
 
-    fireEvent.press(screen.getByText("Filters"));
+    fireEvent.press(screen.getByLabelText("Filters"));
     fireEvent.press(screen.getByText("Red"));
     fireEvent.press(screen.getByText("Apply"));
 
@@ -83,7 +84,7 @@ describe("FilterSheet", () => {
       values: { type: ["red"], status: ["stored"] },
     });
 
-    fireEvent.press(screen.getByText(/Filters/));
+    fireEvent.press(screen.getByLabelText("Filters, 2 active"));
     fireEvent.press(screen.getByText("Clear All"));
     fireEvent.press(screen.getByText("Apply"));
 

--- a/apps/mobile/src/__tests__/components/SortSheet.test.tsx
+++ b/apps/mobile/src/__tests__/components/SortSheet.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from "@testing-library/react-native";
+import { PaperProvider } from "react-native-paper";
+import { SortSheet } from "@/components/SortSheet";
+
+const options = [
+  { label: "Name (A-Z)", value: "name-asc" },
+  { label: "Name (Z-A)", value: "name-desc" },
+];
+
+function renderSortSheet(
+  props: Partial<React.ComponentProps<typeof SortSheet>> = {},
+) {
+  const defaultProps = {
+    options,
+    value: "name-asc",
+    onChange: jest.fn(),
+    ...props,
+  };
+
+  return {
+    ...render(
+      <PaperProvider>
+        <SortSheet {...defaultProps} />
+      </PaperProvider>,
+    ),
+    onChange: defaultProps.onChange,
+  };
+}
+
+describe("SortSheet", () => {
+  it("shows the current sort trigger", () => {
+    renderSortSheet();
+    expect(screen.getByLabelText("Sort, Name (A-Z)")).toBeTruthy();
+  });
+
+  it("opens modal showing sort options", () => {
+    renderSortSheet();
+    fireEvent.press(screen.getByLabelText("Sort, Name (A-Z)"));
+
+    expect(screen.getByText("Sort By")).toBeTruthy();
+    expect(screen.getByText("Name (A-Z)")).toBeTruthy();
+    expect(screen.getByText("Name (Z-A)")).toBeTruthy();
+  });
+
+  it("Apply button calls onChange with the selected sort", () => {
+    const { onChange } = renderSortSheet();
+
+    fireEvent.press(screen.getByLabelText("Sort, Name (A-Z)"));
+    fireEvent.press(screen.getByText("Name (Z-A)"));
+    fireEvent.press(screen.getByText("Apply"));
+
+    expect(onChange).toHaveBeenCalledWith("name-desc");
+  });
+});

--- a/apps/mobile/src/components/DataList.tsx
+++ b/apps/mobile/src/components/DataList.tsx
@@ -206,11 +206,14 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   toolbar: {
+    flexDirection: "row",
+    alignItems: "center",
     paddingHorizontal: 12,
     paddingVertical: 8,
     gap: 8,
   },
   searchbar: {
+    flex: 1,
     minHeight: 0,
   },
   searchbarInput: {
@@ -220,6 +223,7 @@ const styles = StyleSheet.create({
   },
   toolbarActions: {
     flexDirection: "row",
+    flexShrink: 0,
     gap: 8,
   },
   list: {

--- a/apps/mobile/src/components/FilterSheet.tsx
+++ b/apps/mobile/src/components/FilterSheet.tsx
@@ -144,9 +144,9 @@ export function FilterSheet({ filters, values, onChange }: FilterSheetProps) {
           style={styles.triggerButton}
         />
         {activeCount > 0 && (
-          <Badge testID="filter-active-count" style={styles.badge}>
-            {activeCount}
-          </Badge>
+          <View style={styles.badge} pointerEvents="none">
+            <Badge testID="filter-active-count">{activeCount}</Badge>
+          </View>
         )}
       </View>
 

--- a/apps/mobile/src/components/FilterSheet.tsx
+++ b/apps/mobile/src/components/FilterSheet.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   IconButton,
   Chip,
+  Badge,
 } from "react-native-paper";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import type { SelectOption } from "@/lib/types/field";
@@ -115,19 +116,39 @@ export function FilterSheet({ filters, values, onChange }: FilterSheetProps) {
       borderTopColor: theme.colors.outlineVariant,
       gap: 12,
     },
+    trigger: {
+      position: "relative",
+    },
+    triggerButton: {
+      margin: 0,
+    },
+    badge: {
+      position: "absolute",
+      top: -4,
+      right: -4,
+    },
   });
 
   return (
     <>
-      <Button
-        testID="filter-button"
-        mode={activeCount > 0 ? "contained-tonal" : "outlined"}
-        icon="filter-variant"
-        onPress={handleOpen}
-        compact
-      >
-        Filters{activeCount > 0 ? ` (${activeCount})` : ""}
-      </Button>
+      <View style={styles.trigger}>
+        <IconButton
+          testID="filter-button"
+          mode={activeCount > 0 ? "contained-tonal" : "outlined"}
+          icon="filter-variant"
+          accessibilityLabel={
+            activeCount > 0 ? `Filters, ${activeCount} active` : "Filters"
+          }
+          onPress={handleOpen}
+          size={20}
+          style={styles.triggerButton}
+        />
+        {activeCount > 0 && (
+          <Badge testID="filter-active-count" style={styles.badge}>
+            {activeCount}
+          </Badge>
+        )}
+      </View>
 
       <Portal>
         <Modal

--- a/apps/mobile/src/components/SortSheet.tsx
+++ b/apps/mobile/src/components/SortSheet.tsx
@@ -75,18 +75,22 @@ export function SortSheet({ options, value, onChange }: SortSheetProps) {
       borderTopWidth: 1,
       borderTopColor: theme.colors.outlineVariant,
     },
+    triggerButton: {
+      margin: 0,
+    },
   });
 
   return (
     <>
-      <Button
+      <IconButton
+        testID="sort-button"
         mode={currentLabel ? "contained-tonal" : "outlined"}
         icon="sort"
+        accessibilityLabel={currentLabel ? `Sort, ${currentLabel}` : "Sort"}
         onPress={handleOpen}
-        compact
-      >
-        {currentLabel ?? "Sort"}
-      </Button>
+        size={20}
+        style={styles.triggerButton}
+      />
 
       <Portal>
         <Modal


### PR DESCRIPTION
## Summary
- move mobile list filter and sort controls into the search toolbar row
- replace text filter/sort triggers with compact icon controls while preserving the existing modal flows
- add SortSheet component coverage and update FilterSheet assertions for accessible icon triggers

## Tests
- pnpm exec prettier --check apps/mobile/src/components/DataList.tsx apps/mobile/src/components/FilterSheet.tsx apps/mobile/src/components/SortSheet.tsx apps/mobile/src/__tests__/components/FilterSheet.test.tsx apps/mobile/src/__tests__/components/SortSheet.test.tsx
- pnpm --filter @cellarboss/mobile exec tsc --noEmit
- pnpm --filter @cellarboss/mobile docs:build
- CI=1 perl -e 'alarm shift; exec @ARGV' 90 pnpm --filter @cellarboss/mobile exec jest src/__tests__/components/FilterSheet.test.tsx src/__tests__/components/SortSheet.test.tsx --runInBand --watchAll=false --detectOpenHandles
- CI=1 perl -e 'alarm shift; exec @ARGV' 90 pnpm --filter @cellarboss/mobile exec jest src/__tests__/components/DataList.test.tsx --runInBand --watchAll=false --detectOpenHandles
- git diff --check

Fixes #539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned filter and sort controls to use icon triggers for improved visual consistency.
  * Filter active counts now appear as floating badges over the filter icon; accessibility labels include active counts.
  * Toolbar layout improved: horizontal alignment, centred items and a flexible search that expands to available space.

* **Tests**
  * Added SortSheet tests and updated mobile tests to verify accessible labels, modal flows, apply/clear behaviours and presence of active-count test IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
