### PR TITLE
feat: Add tasting note count to wine responses

### DIFF
--- a/apps/backend/src/controllers/wines.controller.ts
+++ b/apps/backend/src/controllers/wines.controller.ts
@@ -1,25 +1,56 @@
 import { db } from "@utils/database.js";
 import { insertReturning, updateReturning } from "@utils/query-helpers.js";
-import type { CreateWine, UpdateWine } from "@cellarboss/types";
+import type { CreateWine, UpdateWine, WineWithCounts } from "@cellarboss/types";
 
-export async function list() {
-  return await db.selectFrom("wine").selectAll().execute();
+type WineRowWithCounts = Omit<WineWithCounts, "tastingNotesCount"> & {
+  tastingNotesCount: number | string | bigint | null;
+};
+
+function toWineWithCounts(row: WineRowWithCounts): WineWithCounts {
+  return {
+    ...row,
+    tastingNotesCount:
+      row.tastingNotesCount == null ? 0 : Number(row.tastingNotesCount),
+  };
 }
 
-export async function getById(id: number) {
-  return await db
+function selectWineWithCounts() {
+  return db
     .selectFrom("wine")
-    .selectAll()
+    .selectAll("wine")
+    .select((eb) =>
+      eb
+        .selectFrom("tastingNote")
+        .innerJoin("vintage", "vintage.id", "tastingNote.vintageId")
+        .select((eb) => eb.fn.count("tastingNote.id").as("count"))
+        .whereRef("vintage.wineId", "=", "wine.id")
+        .as("tastingNotesCount"),
+    );
+}
+
+export async function list(): Promise<WineWithCounts[]> {
+  const rows = await selectWineWithCounts().execute();
+  return rows.map(toWineWithCounts);
+}
+
+export async function getById(id: number): Promise<WineWithCounts | undefined> {
+  const row = await selectWineWithCounts()
     .where("id", "=", id)
     .executeTakeFirst();
+  return row ? toWineWithCounts(row) : undefined;
 }
 
-export async function create(data: CreateWine) {
-  return await insertReturning(db, "wine", data);
+export async function create(data: CreateWine): Promise<WineWithCounts> {
+  const inserted = await insertReturning(db, "wine", data);
+  return (await getById(inserted.id)) as WineWithCounts;
 }
 
-export async function update(id: number, data: UpdateWine) {
-  return await updateReturning(db, "wine", id, data);
+export async function update(
+  id: number,
+  data: UpdateWine,
+): Promise<WineWithCounts> {
+  await updateReturning(db, "wine", id, data);
+  return (await getById(id)) as WineWithCounts;
 }
 
 export async function remove(id: number) {

--- a/apps/backend/src/openapi/schemas.ts
+++ b/apps/backend/src/openapi/schemas.ts
@@ -56,6 +56,11 @@ export const storageResponseSchema = createStorageSchema.extend({
 
 export const wineResponseSchema = createWineSchema.extend({
   id: z.number().describe("Unique identifier"),
+  tastingNotesCount: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe("Number of tasting notes across all vintages for this wine"),
 });
 
 export const vintageResponseSchema = createVintageSchema.extend({

--- a/apps/backend/src/tests/wines.test.ts
+++ b/apps/backend/src/tests/wines.test.ts
@@ -260,6 +260,35 @@ describe("Wine API", () => {
         expect(data.regionId).toBe(testRegionId);
         expect(data.tastingNotesCount).toBe(0);
       });
+
+      it("preserves non-zero tasting note count when updating a wine", async () => {
+        const createRes = await app.request("/wine", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Counted Update Wine",
+            wineMakerId: testWineMakerId,
+            regionId: null,
+            type: "red",
+          }),
+        });
+        const created = await createRes.json();
+        const vintage = await createTestVintage(db, created.id, 2023);
+
+        await createTastingNote(vintage.id, "Update note one");
+        await createTastingNote(vintage.id, "Update note two");
+
+        const res = await app.request(`/wine/${created.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ regionId: testRegionId }),
+        });
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.regionId).toBe(testRegionId);
+        expect(data.tastingNotesCount).toBe(2);
+      });
     });
 
     describe("DELETE /wine/:id", () => {

--- a/apps/backend/src/tests/wines.test.ts
+++ b/apps/backend/src/tests/wines.test.ts
@@ -10,6 +10,7 @@ import {
   createTestCountry,
   createTestGrape,
   createTestVintage,
+  createTestUser,
 } from "./setup";
 import { registerWineRoutes } from "@routes/wines.routes.js";
 import { db } from "@utils/database.js";
@@ -21,7 +22,24 @@ describe("Wine API", () => {
   beforeAll(async () => {
     await runMigrations(db);
     await cleanDatabase(db);
+    await createTestUser(db);
   });
+
+  async function createTastingNote(
+    vintageId: number,
+    notes: string = "Test tasting note",
+  ) {
+    await db
+      .insertInto("tastingNote")
+      .values({
+        vintageId,
+        date: new Date().toISOString(),
+        authorId: "test-user-1",
+        score: 8,
+        notes,
+      })
+      .execute();
+  }
 
   describe("without auth", () => {
     let app: OpenAPIHono;
@@ -80,6 +98,34 @@ describe("Wine API", () => {
         const data = await res.json();
         expect(Array.isArray(data)).toBe(true);
       });
+
+      it("includes tasting note counts for each wine", async () => {
+        const createRes = await app.request("/wine", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Counted List Wine",
+            wineMakerId: testWineMakerId,
+            regionId: testRegionId,
+            type: "red",
+          }),
+        });
+        const created = await createRes.json();
+        const firstVintage = await createTestVintage(db, created.id, 2018);
+        const secondVintage = await createTestVintage(db, created.id, 2019);
+
+        await createTastingNote(firstVintage.id, "First vintage note");
+        await createTastingNote(firstVintage.id, "Second vintage note");
+        await createTastingNote(secondVintage.id, "Another vintage note");
+
+        const res = await app.request("/wine");
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        const wine = data.find((item: any) => item.id === created.id);
+
+        expect(wine).toBeDefined();
+        expect(wine.tastingNotesCount).toBe(3);
+      });
     });
 
     describe("POST /wine", () => {
@@ -107,6 +153,7 @@ describe("Wine API", () => {
         const data = await res.json();
         expect(data).toHaveProperty("id");
         expect(data.name).toBe("Château Margaux");
+        expect(data.tastingNotesCount).toBe(0);
       });
     });
 
@@ -134,6 +181,31 @@ describe("Wine API", () => {
         const data = await res.json();
         expect(data.id).toBe(created.id);
         expect(data.name).toBe("Opus One");
+        expect(data.tastingNotesCount).toBe(0);
+      });
+
+      it("returns tasting note count across wine vintages", async () => {
+        const createRes = await app.request("/wine", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: "Counted Detail Wine",
+            wineMakerId: testWineMakerId,
+            regionId: null,
+            type: "red",
+          }),
+        });
+        const created = await createRes.json();
+        const firstVintage = await createTestVintage(db, created.id, 2021);
+        const secondVintage = await createTestVintage(db, created.id, 2022);
+
+        await createTastingNote(firstVintage.id, "First detail note");
+        await createTastingNote(secondVintage.id, "Second detail note");
+
+        const res = await app.request(`/wine/${created.id}`);
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.tastingNotesCount).toBe(2);
       });
     });
 
@@ -186,6 +258,7 @@ describe("Wine API", () => {
         expect(res.status).toBe(200);
         const data = await res.json();
         expect(data.regionId).toBe(testRegionId);
+        expect(data.tastingNotesCount).toBe(0);
       });
     });
 

--- a/packages/common/src/resources/wines.ts
+++ b/packages/common/src/resources/wines.ts
@@ -1,29 +1,34 @@
-import type { Wine } from "@cellarboss/types";
+import type { Wine, WineWithCounts } from "@cellarboss/types";
 import type { ApiResult, RequestFn } from "../types";
 
 export function winesResource(request: RequestFn) {
   return {
-    getAll: (): Promise<ApiResult<Wine[]>> => request<Wine[]>("wine", "GET"),
+    getAll: (): Promise<ApiResult<WineWithCounts[]>> =>
+      request<WineWithCounts[]>("wine", "GET"),
 
-    getById: (id: number): Promise<ApiResult<Wine>> =>
-      request<Wine>("wine/" + id, "GET"),
+    getById: (id: number): Promise<ApiResult<WineWithCounts>> =>
+      request<WineWithCounts>("wine/" + id, "GET"),
 
-    create: (wine: Wine): Promise<ApiResult<Wine>> => {
+    create: (wine: Wine): Promise<ApiResult<WineWithCounts>> => {
       const body = {
         ...wine,
         wineMakerId: Number(wine.wineMakerId),
         regionId: wine.regionId ? Number(wine.regionId) : null,
       };
-      return request<Wine>("wine", "POST", JSON.stringify(body));
+      return request<WineWithCounts>("wine", "POST", JSON.stringify(body));
     },
 
-    update: (wine: Wine): Promise<ApiResult<Wine>> => {
+    update: (wine: Wine): Promise<ApiResult<WineWithCounts>> => {
       const body = {
         ...wine,
         wineMakerId: Number(wine.wineMakerId),
         regionId: wine.regionId ? Number(wine.regionId) : null,
       };
-      return request<Wine>("wine/" + wine.id, "PUT", JSON.stringify(body));
+      return request<WineWithCounts>(
+        "wine/" + wine.id,
+        "PUT",
+        JSON.stringify(body),
+      );
     },
 
     delete: (id: number): Promise<ApiResult<boolean>> =>

--- a/packages/mock-server/src/routes/wines.ts
+++ b/packages/mock-server/src/routes/wines.ts
@@ -4,16 +4,28 @@ import { createWineSchema, updateWineSchema } from "@cellarboss/validators";
 
 let nextId = 1000;
 
+function withTastingNotesCount(wine: any, state: MockState) {
+  const vintageIds = new Set(
+    state.vintages.filter((v) => v.wineId === wine.id).map((v) => v.id),
+  );
+  const tastingNotesCount = state.tastingNotes.filter((note) =>
+    vintageIds.has(note.vintageId),
+  ).length;
+  return { ...wine, tastingNotesCount };
+}
+
 export function registerWineRoutes(app: Hono, state: MockState) {
   app.get("/api/wine", (c) => {
-    return c.json(state.wines);
+    return c.json(
+      state.wines.map((wine) => withTastingNotesCount(wine, state)),
+    );
   });
 
   app.get("/api/wine/:id", (c) => {
     const id = Number(c.req.param("id"));
     const wine = state.wines.find((w) => w.id === id);
     if (!wine) return c.json({ error: "Not found" }, 404);
-    return c.json(wine);
+    return c.json(withTastingNotesCount(wine, state));
   });
 
   app.post("/api/wine", async (c) => {
@@ -22,7 +34,7 @@ export function registerWineRoutes(app: Hono, state: MockState) {
     if (!result.success) return c.json({ error: result.error.issues }, 400);
     const wine = { id: ++nextId, ...result.data };
     state.wines.push(wine);
-    return c.json(wine, 201);
+    return c.json(withTastingNotesCount(wine, state), 201);
   });
 
   app.put("/api/wine/:id", async (c) => {
@@ -33,7 +45,7 @@ export function registerWineRoutes(app: Hono, state: MockState) {
     const idx = state.wines.findIndex((w) => w.id === id);
     if (idx === -1) return c.json({ error: "Not found" }, 404);
     state.wines[idx] = { ...state.wines[idx], ...result.data };
-    return c.json(state.wines[idx]);
+    return c.json(withTastingNotesCount(state.wines[idx], state));
   });
 
   app.delete("/api/wine/:id", (c) => {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -6,7 +6,7 @@ export type { Location, CreateLocation, UpdateLocation } from "./location";
 export type { Region, CreateRegion, UpdateRegion } from "./region";
 export type { Storage, CreateStorage, UpdateStorage } from "./storage";
 export type { Vintage, CreateVintage, UpdateVintage } from "./vintage";
-export type { Wine, CreateWine, UpdateWine } from "./wine";
+export type { Wine, WineWithCounts, CreateWine, UpdateWine } from "./wine";
 export type { WineGrape, CreateWineGrape, UpdateWineGrape } from "./winegrape";
 export type { WineMaker, CreateWineMaker, UpdateWineMaker } from "./winemaker";
 export type { Setting, UpdateSetting } from "./setting";

--- a/packages/types/src/wine.ts
+++ b/packages/types/src/wine.ts
@@ -13,6 +13,10 @@ export interface Wine extends GenericType {
     | "dessert";
 }
 
+export interface WineWithCounts extends Wine {
+  tastingNotesCount: number;
+}
+
 export type CreateWine = Omit<Wine, "id">;
 
 export type UpdateWine = Partial<Omit<Wine, "id">>;


### PR DESCRIPTION
## Summary
- add a `tastingNotesCount` field to backend wine list, detail, create, and update responses
- expose the enriched `WineWithCounts` type through the shared client
- align the mock server wine responses and cover wine counts across vintages in backend tests

## Tests
- pnpm exec prettier --check apps/backend/src/controllers/wines.controller.ts apps/backend/src/openapi/schemas.ts apps/backend/src/tests/wines.test.ts packages/types/src/wine.ts packages/types/src/index.ts packages/common/src/resources/wines.ts packages/mock-server/src/routes/wines.ts
- pnpm --filter @cellarboss/backend exec tsc --noEmit
- pnpm --filter @cellarboss/types exec tsc --noEmit
- pnpm --filter @cellarboss/common exec tsc --noEmit
- pnpm --filter @cellarboss/backend exec vitest run src/tests/wines.test.ts
- pnpm --filter @cellarboss/common exec vitest run src/__tests__/api-client/wines.test.ts
- pnpm --filter @cellarboss/backend generate:docs
- pnpm --filter @cellarboss/backend exec vitest run
- pnpm --filter @cellarboss/common exec vitest run
- git diff --check

Refs #354

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wine records now include a tastingNotesCount field aggregating tasting notes across all vintages.
  * List, retrieve, create and update endpoints return wines with tastingNotesCount.
  * Public types and client resources updated to expose the new shape.

* **Tests**
  * API tests extended to seed data and validate tastingNotesCount across scenarios (per-wine and per-vintage aggregation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->