### PR TITLE
feat: Persist DataTable column visibility

### DIFF
--- a/apps/backend/src/controllers/settings.controller.ts
+++ b/apps/backend/src/controllers/settings.controller.ts
@@ -1,9 +1,11 @@
 import { db } from "@utils/database.js";
 import { updateReturning } from "@utils/query-helpers.js";
 import type { UpdateSetting } from "@cellarboss/types";
+import { isUserPreferenceSettingKey } from "./user-preferences.controller.js";
 
 export async function list() {
-  return await db.selectFrom("setting").selectAll().execute();
+  const settings = await db.selectFrom("setting").selectAll().execute();
+  return settings.filter((setting) => !isUserPreferenceSettingKey(setting.key));
 }
 
 export async function getByKey(key: string) {

--- a/apps/backend/src/controllers/settings.controller.ts
+++ b/apps/backend/src/controllers/settings.controller.ts
@@ -1,11 +1,14 @@
 import { db } from "@utils/database.js";
 import { updateReturning } from "@utils/query-helpers.js";
 import type { UpdateSetting } from "@cellarboss/types";
-import { isUserPreferenceSettingKey } from "./user-preferences.controller.js";
+import { USER_PREFERENCE_STORAGE_PREFIX } from "./user-preferences.controller.js";
 
 export async function list() {
-  const settings = await db.selectFrom("setting").selectAll().execute();
-  return settings.filter((setting) => !isUserPreferenceSettingKey(setting.key));
+  return await db
+    .selectFrom("setting")
+    .selectAll()
+    .where("key", "not like", `${USER_PREFERENCE_STORAGE_PREFIX}%`)
+    .execute();
 }
 
 export async function getByKey(key: string) {

--- a/apps/backend/src/controllers/user-preferences.controller.ts
+++ b/apps/backend/src/controllers/user-preferences.controller.ts
@@ -1,0 +1,74 @@
+import type { JsonValue, UserPreference } from "@cellarboss/types";
+import { db } from "@utils/database.js";
+
+const STORAGE_PREFIX = "userPreference:";
+
+export function isUserPreferenceSettingKey(key: string) {
+  return key.startsWith(STORAGE_PREFIX);
+}
+
+function storageKey(userId: string, key: string) {
+  return `${STORAGE_PREFIX}${userId}:${key}`;
+}
+
+function parsePreferenceValue(value: string): JsonValue {
+  return JSON.parse(value) as JsonValue;
+}
+
+function toUserPreference(key: string, row: { value: string }): UserPreference {
+  return {
+    key,
+    value: parsePreferenceValue(row.value),
+  };
+}
+
+export async function getByKey(
+  userId: string,
+  key: string,
+): Promise<UserPreference | undefined> {
+  const row = await db
+    .selectFrom("setting")
+    .select(["value"])
+    .where("key", "=", storageKey(userId, key))
+    .executeTakeFirst();
+
+  return row ? toUserPreference(key, row) : undefined;
+}
+
+export async function upsert(
+  userId: string,
+  key: string,
+  value: JsonValue,
+): Promise<UserPreference> {
+  const storedKey = storageKey(userId, key);
+  const storedValue = JSON.stringify(value);
+  const existing = await db
+    .selectFrom("setting")
+    .select("key")
+    .where("key", "=", storedKey)
+    .executeTakeFirst();
+
+  if (existing) {
+    await db
+      .updateTable("setting")
+      .set({ value: storedValue })
+      .where("key", "=", storedKey)
+      .execute();
+  } else {
+    await db
+      .insertInto("setting")
+      .values({ key: storedKey, value: storedValue })
+      .execute();
+  }
+
+  return { key, value };
+}
+
+export async function remove(userId: string, key: string): Promise<boolean> {
+  const result = await db
+    .deleteFrom("setting")
+    .where("key", "=", storageKey(userId, key))
+    .executeTakeFirst();
+
+  return Number(result.numDeletedRows ?? 0) > 0;
+}

--- a/apps/backend/src/controllers/user-preferences.controller.ts
+++ b/apps/backend/src/controllers/user-preferences.controller.ts
@@ -1,14 +1,15 @@
 import type { JsonValue, UserPreference } from "@cellarboss/types";
 import { db } from "@utils/database.js";
+import { env } from "@utils/env.js";
 
-const STORAGE_PREFIX = "userPreference:";
+export const USER_PREFERENCE_STORAGE_PREFIX = "userPreference:";
 
 export function isUserPreferenceSettingKey(key: string) {
-  return key.startsWith(STORAGE_PREFIX);
+  return key.startsWith(USER_PREFERENCE_STORAGE_PREFIX);
 }
 
 function storageKey(userId: string, key: string) {
-  return `${STORAGE_PREFIX}${userId}:${key}`;
+  return `${USER_PREFERENCE_STORAGE_PREFIX}${userId}:${key}`;
 }
 
 function parsePreferenceValue(value: string): JsonValue {
@@ -42,24 +43,16 @@ export async function upsert(
 ): Promise<UserPreference> {
   const storedKey = storageKey(userId, key);
   const storedValue = JSON.stringify(value);
-  const existing = await db
-    .selectFrom("setting")
-    .select("key")
-    .where("key", "=", storedKey)
-    .executeTakeFirst();
-
-  if (existing) {
-    await db
-      .updateTable("setting")
-      .set({ value: storedValue })
-      .where("key", "=", storedKey)
-      .execute();
-  } else {
-    await db
-      .insertInto("setting")
-      .values({ key: storedKey, value: storedValue })
-      .execute();
-  }
+  const query = db
+    .insertInto("setting")
+    .values({ key: storedKey, value: storedValue });
+  await (
+    env.DATABASE_TYPE === "mysql"
+      ? query.onDuplicateKeyUpdate({ value: storedValue })
+      : query.onConflict((oc) =>
+          oc.column("key").doUpdateSet({ value: storedValue }),
+        )
+  ).execute();
 
   return { key, value };
 }

--- a/apps/backend/src/openapi/schemas.ts
+++ b/apps/backend/src/openapi/schemas.ts
@@ -12,6 +12,7 @@ import {
   createWineGrapeSchema,
   createWineMakerSchema,
   createWineSchema,
+  jsonValueSchema,
 } from "@cellarboss/validators";
 export { imageResponseSchema } from "@cellarboss/validators";
 
@@ -86,6 +87,11 @@ export const tastingNoteResponseSchema = createTastingNoteSchema.extend({
 export const settingResponseSchema = z.object({
   key: z.string().describe("Setting key"),
   value: z.string().describe("Setting value"),
+});
+
+export const userPreferenceResponseSchema = z.object({
+  key: z.string().describe("Preference key"),
+  value: jsonValueSchema.describe("JSON preference value"),
 });
 
 export const userResponseSchema = z.object({

--- a/apps/backend/src/openapi/schemas.ts
+++ b/apps/backend/src/openapi/schemas.ts
@@ -12,9 +12,17 @@ import {
   createWineGrapeSchema,
   createWineMakerSchema,
   createWineSchema,
-  jsonValueSchema,
 } from "@cellarboss/validators";
 export { imageResponseSchema } from "@cellarboss/validators";
+
+const openApiJsonValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(z.any()),
+  z.record(z.string(), z.any()),
+]);
 
 // Shared error/success responses
 export const errorSchema = z.object({
@@ -91,7 +99,7 @@ export const settingResponseSchema = z.object({
 
 export const userPreferenceResponseSchema = z.object({
   key: z.string().describe("Preference key"),
-  value: jsonValueSchema.describe("JSON preference value"),
+  value: openApiJsonValueSchema.describe("JSON preference value"),
 });
 
 export const userResponseSchema = z.object({

--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -12,6 +12,7 @@ import { registerWineMakerRoutes } from "./winemakers.routes";
 import { registerSettingsRoutes } from "./settings.routes";
 import { registerTastingNoteRoutes } from "./tasting-notes.routes";
 import { registerUserRoutes } from "./users.routes";
+import { registerUserPreferenceRoutes } from "./user-preferences.routes";
 import { registerVersionRoutes } from "./version.routes";
 import { registerImageRoutes } from "./images.routes";
 
@@ -29,6 +30,7 @@ export function registerRoutes(app: OpenAPIHono) {
   registerSettingsRoutes(app);
   registerTastingNoteRoutes(app);
   registerUserRoutes(app);
+  registerUserPreferenceRoutes(app);
   registerVersionRoutes(app);
   registerImageRoutes(app);
 }

--- a/apps/backend/src/routes/user-preferences.routes.ts
+++ b/apps/backend/src/routes/user-preferences.routes.ts
@@ -1,9 +1,6 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
 import type { UpsertUserPreference } from "@cellarboss/types";
-import {
-  upsertUserPreferenceSchema,
-  userPreferenceKeySchema,
-} from "@cellarboss/validators";
+import { userPreferenceKeySchema } from "@cellarboss/validators";
 import * as preferencesController from "@controllers/user-preferences.controller.js";
 import { requireAuth } from "@middleware/auth.middleware.js";
 import { jsonContent } from "@openapi/helpers.js";
@@ -12,6 +9,19 @@ import {
   successSchema,
   userPreferenceResponseSchema,
 } from "@openapi/schemas.js";
+
+const userPreferenceValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(z.any()),
+  z.record(z.string(), z.any()),
+]);
+
+const upsertUserPreferenceRequestSchema = z.object({
+  value: userPreferenceValueSchema.describe("JSON preference value"),
+});
 
 const keyParamSchema = z.object({
   key: userPreferenceKeySchema.openapi({
@@ -42,7 +52,7 @@ const upsertRoute = createRoute({
   summary: "Create or update a user preference",
   request: {
     params: keyParamSchema,
-    body: jsonContent(upsertUserPreferenceSchema, "Preference value"),
+    body: jsonContent(upsertUserPreferenceRequestSchema, "Preference value"),
   },
   responses: {
     200: jsonContent(userPreferenceResponseSchema, "The saved preference"),

--- a/apps/backend/src/routes/user-preferences.routes.ts
+++ b/apps/backend/src/routes/user-preferences.routes.ts
@@ -39,6 +39,7 @@ const getRoute = createRoute({
   request: { params: keyParamSchema },
   responses: {
     200: jsonContent(userPreferenceResponseSchema, "The user preference"),
+    400: jsonContent(errorSchema, "Bad Request"),
     401: jsonContent(errorSchema, "Unauthorized"),
     404: jsonContent(errorSchema, "Not found"),
   },
@@ -56,6 +57,7 @@ const upsertRoute = createRoute({
   },
   responses: {
     200: jsonContent(userPreferenceResponseSchema, "The saved preference"),
+    400: jsonContent(errorSchema, "Bad Request"),
     401: jsonContent(errorSchema, "Unauthorized"),
     422: jsonContent(errorSchema, "Validation error"),
   },
@@ -70,6 +72,7 @@ const deleteRoute = createRoute({
   request: { params: keyParamSchema },
   responses: {
     200: jsonContent(successSchema, "Preference deleted"),
+    400: jsonContent(errorSchema, "Bad Request"),
     401: jsonContent(errorSchema, "Unauthorized"),
   },
 });

--- a/apps/backend/src/routes/user-preferences.routes.ts
+++ b/apps/backend/src/routes/user-preferences.routes.ts
@@ -1,0 +1,96 @@
+import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
+import type { UpsertUserPreference } from "@cellarboss/types";
+import {
+  upsertUserPreferenceSchema,
+  userPreferenceKeySchema,
+} from "@cellarboss/validators";
+import * as preferencesController from "@controllers/user-preferences.controller.js";
+import { requireAuth } from "@middleware/auth.middleware.js";
+import { jsonContent } from "@openapi/helpers.js";
+import {
+  errorSchema,
+  successSchema,
+  userPreferenceResponseSchema,
+} from "@openapi/schemas.js";
+
+const keyParamSchema = z.object({
+  key: userPreferenceKeySchema.openapi({
+    description: "User preference key",
+    example: "datatable.wines.columnVisibility",
+  }),
+});
+
+const getRoute = createRoute({
+  method: "get",
+  path: "/{key}",
+  tags: ["Preferences"],
+  security: [{ cookieAuth: [] }],
+  summary: "Get a user preference",
+  request: { params: keyParamSchema },
+  responses: {
+    200: jsonContent(userPreferenceResponseSchema, "The user preference"),
+    401: jsonContent(errorSchema, "Unauthorized"),
+    404: jsonContent(errorSchema, "Not found"),
+  },
+});
+
+const upsertRoute = createRoute({
+  method: "put",
+  path: "/{key}",
+  tags: ["Preferences"],
+  security: [{ cookieAuth: [] }],
+  summary: "Create or update a user preference",
+  request: {
+    params: keyParamSchema,
+    body: jsonContent(upsertUserPreferenceSchema, "Preference value"),
+  },
+  responses: {
+    200: jsonContent(userPreferenceResponseSchema, "The saved preference"),
+    401: jsonContent(errorSchema, "Unauthorized"),
+    422: jsonContent(errorSchema, "Validation error"),
+  },
+});
+
+const deleteRoute = createRoute({
+  method: "delete",
+  path: "/{key}",
+  tags: ["Preferences"],
+  security: [{ cookieAuth: [] }],
+  summary: "Delete a user preference",
+  request: { params: keyParamSchema },
+  responses: {
+    200: jsonContent(successSchema, "Preference deleted"),
+    401: jsonContent(errorSchema, "Unauthorized"),
+  },
+});
+
+export function registerUserPreferenceRoutes(app: OpenAPIHono) {
+  const preferences = new OpenAPIHono();
+
+  preferences.use("*", requireAuth);
+
+  preferences.openapi(getRoute, async (c) => {
+    const user = c.get("user" as never) as { id: string };
+    const key = c.req.param("key");
+    const data = await preferencesController.getByKey(user.id, key);
+    if (!data) return c.json({ error: "Not found" }, 404);
+    return c.json(data, 200);
+  });
+
+  preferences.openapi(upsertRoute, async (c) => {
+    const user = c.get("user" as never) as { id: string };
+    const key = c.req.param("key");
+    const body = c.req.valid("json") as UpsertUserPreference;
+    const data = await preferencesController.upsert(user.id, key, body.value);
+    return c.json(data, 200);
+  });
+
+  preferences.openapi(deleteRoute, async (c) => {
+    const user = c.get("user" as never) as { id: string };
+    const key = c.req.param("key");
+    await preferencesController.remove(user.id, key);
+    return c.json({ success: true }, 200);
+  });
+
+  app.route("/preferences", preferences);
+}

--- a/apps/backend/src/tests/user-preferences.test.ts
+++ b/apps/backend/src/tests/user-preferences.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import type { OpenAPIHono } from "@hono/zod-openapi";
+import {
+  cleanDatabase,
+  createTestApp,
+  createTestAppWithAuth,
+  runMigrations,
+} from "./setup";
+import { registerUserPreferenceRoutes } from "@routes/user-preferences.routes.js";
+import { registerSettingsRoutes } from "@routes/settings.routes.js";
+import { db } from "@utils/database.js";
+
+describe("User Preferences API", () => {
+  beforeAll(async () => {
+    await runMigrations(db);
+    await cleanDatabase(db);
+  });
+
+  describe("unauthenticated access", () => {
+    let app: OpenAPIHono;
+
+    beforeEach(() => {
+      app = createTestApp();
+      registerUserPreferenceRoutes(app);
+    });
+
+    it("GET /preferences/:key returns 401", async () => {
+      const res = await app.request("/preferences/datatable.wines.columns");
+      expect(res.status).toBe(401);
+    });
+
+    it("PUT /preferences/:key returns 401", async () => {
+      const res = await app.request("/preferences/datatable.wines.columns", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: { name: true } }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("DELETE /preferences/:key returns 401", async () => {
+      const res = await app.request("/preferences/datatable.wines.columns", {
+        method: "DELETE",
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("authenticated access", () => {
+    let app: OpenAPIHono;
+
+    beforeEach(async () => {
+      await cleanDatabase(db);
+      app = createTestAppWithAuth("user-a", "user-a@example.com");
+      registerUserPreferenceRoutes(app);
+    });
+
+    it("returns 404 when a preference has not been saved", async () => {
+      const res = await app.request("/preferences/datatable.wines.columns");
+      expect(res.status).toBe(404);
+    });
+
+    it("saves and returns rich JSON preference values", async () => {
+      const value = {
+        name: true,
+        region: false,
+        nested: { pinned: ["name", "region"], compact: true },
+      };
+
+      const putRes = await app.request("/preferences/datatable.wines.columns", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value }),
+      });
+
+      expect(putRes.status).toBe(200);
+      await expect(putRes.json()).resolves.toEqual({
+        key: "datatable.wines.columns",
+        value,
+      });
+
+      const getRes = await app.request("/preferences/datatable.wines.columns");
+      expect(getRes.status).toBe(200);
+      await expect(getRes.json()).resolves.toEqual({
+        key: "datatable.wines.columns",
+        value,
+      });
+    });
+
+    it("isolates preferences by authenticated user", async () => {
+      await app.request("/preferences/datatable.wines.columns", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: { region: false } }),
+      });
+
+      const otherUserApp = createTestAppWithAuth(
+        "user-b",
+        "user-b@example.com",
+      );
+      registerUserPreferenceRoutes(otherUserApp);
+
+      const res = await otherUserApp.request(
+        "/preferences/datatable.wines.columns",
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("deletes a saved preference", async () => {
+      await app.request("/preferences/datatable.wines.columns", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: { region: false } }),
+      });
+
+      const deleteRes = await app.request(
+        "/preferences/datatable.wines.columns",
+        { method: "DELETE" },
+      );
+      expect(deleteRes.status).toBe(200);
+      await expect(deleteRes.json()).resolves.toEqual({ success: true });
+
+      const getRes = await app.request("/preferences/datatable.wines.columns");
+      expect(getRes.status).toBe(404);
+    });
+
+    it("rejects invalid preference keys", async () => {
+      const res = await app.request("/preferences/bad key", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: true }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("does not expose user preferences in the system settings list", async () => {
+      await app.request("/preferences/datatable.wines.columns", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: { region: false } }),
+      });
+
+      const settingsApp = createTestApp();
+      registerSettingsRoutes(settingsApp);
+
+      const res = await settingsApp.request("/settings");
+      expect(res.status).toBe(200);
+      const settings = await res.json();
+      expect(settings).toEqual([]);
+    });
+  });
+});

--- a/apps/web/app/bottles/page.tsx
+++ b/apps/web/app/bottles/page.tsx
@@ -295,6 +295,7 @@ export default function BottlesPage() {
     {
       id: "vintage",
       header: "Wine",
+      meta: { isHideable: false },
       enableSorting: true,
       enableColumnFilter: true,
       accessorFn: (row: Bottle) =>
@@ -407,7 +408,7 @@ export default function BottlesPage() {
       header: "Size",
       enableSorting: true,
       enableColumnFilter: true,
-      meta: { hidden: true },
+      meta: { defaultVisible: false },
     },
     {
       accessorKey: "status",
@@ -420,6 +421,8 @@ export default function BottlesPage() {
       id: "options",
       header: "",
       size: 100,
+      enableHiding: false,
+      meta: { isHideable: false },
       enableSorting: false,
       cell: ({ row }: { row: { original: Bottle } }) => (
         <div className="flex gap-1 justify-center mx-5">
@@ -456,7 +459,7 @@ export default function BottlesPage() {
       header: "",
       enableColumnFilter: true,
       enableSorting: false,
-      meta: { hidden: true },
+      meta: { isSuppressed: true, defaultVisible: false },
       accessorFn: (row: Bottle) =>
         String(vintageMap.get(row.vintageId)?.wineId ?? ""),
     },
@@ -466,7 +469,7 @@ export default function BottlesPage() {
       header: "",
       enableColumnFilter: true,
       enableSorting: false,
-      meta: { hidden: true },
+      meta: { isSuppressed: true, defaultVisible: false },
       accessorFn: (row: Bottle) => vintageMap.get(row.vintageId)?.year ?? 0,
     },
     {
@@ -475,7 +478,7 @@ export default function BottlesPage() {
       header: "",
       enableColumnFilter: true,
       enableSorting: false,
-      meta: { hidden: true },
+      meta: { isSuppressed: true, defaultVisible: false },
       accessorFn: (row: Bottle) =>
         wineMap.get(vintageMap.get(row.vintageId)?.wineId ?? 0)?.type ?? "",
     },
@@ -485,7 +488,7 @@ export default function BottlesPage() {
       header: "",
       enableColumnFilter: true,
       enableSorting: false,
-      meta: { hidden: true },
+      meta: { isSuppressed: true, defaultVisible: false },
       accessorFn: (row: Bottle) => {
         const vintage = vintageMap.get(row.vintageId);
         if (!vintage) return "unknown";
@@ -502,7 +505,7 @@ export default function BottlesPage() {
       header: "",
       enableColumnFilter: true,
       enableSorting: false,
-      meta: { hidden: true },
+      meta: { isSuppressed: true, defaultVisible: false },
       accessorFn: (row: Bottle) => {
         const vintage = vintageMap.get(row.vintageId);
         if (!vintage) return "";
@@ -520,6 +523,7 @@ export default function BottlesPage() {
     <section>
       <PageHeader title="Bottles" />
       <DataTable<Bottle>
+        tableId="bottles"
         data={bottles}
         columns={columns}
         filterColumnName="vintage"

--- a/apps/web/app/countries/page.tsx
+++ b/apps/web/app/countries/page.tsx
@@ -51,6 +51,7 @@ export default function CountriesPage() {
     {
       accessorKey: "name",
       header: "Country Name",
+      meta: { isHideable: false },
       enableColumnFilter: true,
       enableSorting: true,
       cell: ({ row }: { row: { original: Country } }) => {
@@ -64,6 +65,8 @@ export default function CountriesPage() {
       id: "options",
       header: "",
       size: 100,
+      enableHiding: false,
+      meta: { isHideable: false },
       enableSorting: false,
       cell: ({ row }: { row: { original: Country } }) => {
         return (
@@ -83,6 +86,7 @@ export default function CountriesPage() {
     <section>
       <PageHeader title="Countries" />
       <DataTable<Country>
+        tableId="countries"
         data={countriesList}
         columns={columns}
         filterColumnName="name"

--- a/apps/web/app/grapes/page.tsx
+++ b/apps/web/app/grapes/page.tsx
@@ -48,6 +48,7 @@ export default function GrapesPage() {
     {
       accessorKey: "name",
       header: "Grape Name",
+      meta: { isHideable: false },
       enableColumnFilter: true,
       enableSorting: true,
       cell: ({ row }: { row: { original: Grape } }) => {
@@ -59,6 +60,8 @@ export default function GrapesPage() {
       id: "options",
       header: "",
       size: 100,
+      enableHiding: false,
+      meta: { isHideable: false },
       enableSorting: false,
       cell: ({ row }: { row: { original: Grape } }) => {
         return (
@@ -78,6 +81,7 @@ export default function GrapesPage() {
     <section>
       <PageHeader title="Grapes" />
       <DataTable<Grape>
+        tableId="grapes"
         data={grapesList}
         columns={columns}
         filterColumnName="name"

--- a/apps/web/app/locations/page.tsx
+++ b/apps/web/app/locations/page.tsx
@@ -51,6 +51,7 @@ export default function LocationsPage() {
     {
       accessorKey: "name",
       header: "Location Name",
+      meta: { isHideable: false },
       enableColumnFilter: true,
       enableSorting: true,
       cell: ({ row }: { row: { original: Location } }) => {
@@ -64,6 +65,8 @@ export default function LocationsPage() {
       id: "options",
       header: "",
       size: 100,
+      enableHiding: false,
+      meta: { isHideable: false },
       enableSorting: false,
       cell: ({ row }: { row: { original: Location } }) => {
         return (
@@ -83,6 +86,7 @@ export default function LocationsPage() {
     <section>
       <PageHeader title="Locations" />
       <DataTable<Location>
+        tableId="locations"
         data={locationsList}
         columns={columns}
         filterColumnName="name"

--- a/apps/web/app/regions/page.tsx
+++ b/apps/web/app/regions/page.tsx
@@ -95,6 +95,7 @@ export default function RegionsPage() {
     {
       accessorKey: "name",
       header: "Region Name",
+      meta: { isHideable: false },
       enableColumnFilter: true,
       enableSorting: true,
       cell: ({ row }: { row: { original: Region } }) => {
@@ -120,6 +121,8 @@ export default function RegionsPage() {
       id: "options",
       header: "",
       size: 100,
+      enableHiding: false,
+      meta: { isHideable: false },
       enableSorting: false,
       cell: ({ row }: { row: { original: Region } }) => {
         return (
@@ -139,6 +142,7 @@ export default function RegionsPage() {
     <section>
       <PageHeader title="Regions" />
       <DataTable<Region>
+        tableId="regions"
         data={regionsList}
         columns={columns}
         filterColumnName="name"

--- a/apps/web/app/storages/page.tsx
+++ b/apps/web/app/storages/page.tsx
@@ -102,6 +102,7 @@ export default function StoragesPage() {
     {
       accessorKey: "name",
       header: "Storage Name",
+      meta: { isHideable: false },
       enableColumnFilter: true,
       enableSorting: true,
       cell: ({ row }) => {
@@ -141,6 +142,8 @@ export default function StoragesPage() {
       id: "options",
       header: "",
       size: 100,
+      enableHiding: false,
+      meta: { isHideable: false },
       enableSorting: false,
       cell: ({ row }) => {
         return (
@@ -160,6 +163,7 @@ export default function StoragesPage() {
     <section>
       <PageHeader title="Storages" />
       <DataTable<TreeNode<Storage>>
+        tableId="storages"
         data={treeData}
         columns={columns}
         filterColumnName="name"

--- a/apps/web/app/users/page.tsx
+++ b/apps/web/app/users/page.tsx
@@ -67,6 +67,7 @@ export default function UsersPage() {
     {
       accessorKey: "name",
       header: "Name",
+      meta: { isHideable: false },
       enableColumnFilter: true,
       enableSorting: true,
       cell: ({ row }: { row: { original: AdminUser } }) => (
@@ -91,6 +92,8 @@ export default function UsersPage() {
       id: "options",
       header: "",
       size: 100,
+      enableHiding: false,
+      meta: { isHideable: false },
       enableSorting: false,
       cell: ({ row }: { row: { original: AdminUser } }) => (
         <div className="flex gap-1 justify-center mx-5">
@@ -108,6 +111,7 @@ export default function UsersPage() {
     <section>
       <PageHeader title="Users" />
       <DataTable<AdminUser>
+        tableId="users"
         data={usersList}
         columns={columns}
         filterColumnName="name"

--- a/apps/web/app/winemakers/page.tsx
+++ b/apps/web/app/winemakers/page.tsx
@@ -51,6 +51,7 @@ export default function WinemakersPage() {
     {
       accessorKey: "name",
       header: "Winemaker Name",
+      meta: { isHideable: false },
       enableColumnFilter: true,
       enableSorting: true,
       cell: ({ row }: { row: { original: WineMaker } }) => {
@@ -64,6 +65,8 @@ export default function WinemakersPage() {
       id: "options",
       header: "",
       size: 100,
+      enableHiding: false,
+      meta: { isHideable: false },
       enableSorting: false,
       cell: ({ row }: { row: { original: WineMaker } }) => {
         return (
@@ -83,6 +86,7 @@ export default function WinemakersPage() {
     <section>
       <PageHeader title="Winemakers" />
       <DataTable<WineMaker>
+        tableId="winemakers"
         data={winemakersList}
         columns={columns}
         filterColumnName="name"

--- a/apps/web/app/wines/page.tsx
+++ b/apps/web/app/wines/page.tsx
@@ -164,6 +164,7 @@ export default function WinesPage() {
     {
       accessorKey: "name",
       header: "Wine Name",
+      meta: { isHideable: false },
       enableColumnFilter: true,
       enableSorting: true,
       cell: ({ row }) => (
@@ -182,7 +183,7 @@ export default function WinesPage() {
       header: "Type",
       enableColumnFilter: false,
       enableSorting: false,
-      meta: { hidden: true },
+      meta: { defaultVisible: false },
     },
     {
       id: "winemaker",
@@ -256,13 +257,15 @@ export default function WinesPage() {
       header: "Country",
       enableColumnFilter: false,
       enableSorting: false,
-      meta: { hidden: true },
+      meta: { isSuppressed: true, defaultVisible: false },
     },
     {
       accessorKey: "options",
       id: "options",
       header: "",
       size: 100,
+      enableHiding: false,
+      meta: { isHideable: false },
       enableSorting: false,
       cell: ({ row }) => {
         return (
@@ -288,6 +291,7 @@ export default function WinesPage() {
     <section>
       <PageHeader title="Wines" />
       <DataTable<Wine>
+        tableId="wines"
         data={winesList}
         columns={columns}
         filterColumnName="name"

--- a/apps/web/components/datatable/components/DataTable.tsx
+++ b/apps/web/components/datatable/components/DataTable.tsx
@@ -145,6 +145,11 @@ export function DataTable<T>({
       hasAppliedColumnPreference.current = true;
       return;
     }
+    if (columnPreference.isError) {
+      setColumnVisibility(mergeColumnVisibility(processedColumns));
+      hasAppliedColumnPreference.current = true;
+      return;
+    }
     if (!columnPreference.isSuccess) return;
 
     const savedVisibility = isColumnVisibilityPreference(
@@ -158,6 +163,7 @@ export function DataTable<T>({
     hasAppliedColumnPreference.current = true;
   }, [
     columnPreference.data,
+    columnPreference.isError,
     columnPreference.isSuccess,
     preferenceKey,
     processedColumns,

--- a/apps/web/components/datatable/components/DataTable.tsx
+++ b/apps/web/components/datatable/components/DataTable.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Fragment, ReactNode } from "react";
+import {
+  Fragment,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 import {
   ColumnDef,
   getCoreRowModel,
@@ -10,6 +17,8 @@ import {
   getExpandedRowModel,
   useReactTable,
   Row,
+  Updater,
+  VisibilityState,
 } from "@tanstack/react-table";
 
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
@@ -38,6 +47,17 @@ import { processColumnsWithFilters } from "../utils/processColumns";
 import { getContextRows } from "../utils/contextRowCalculations";
 import { calculatePaginationMetrics } from "../utils/paginationCalculations";
 import { createTableStateUpdater } from "../hooks/useDataTableState";
+import { DataTableColumnVisibilityControl } from "./DataTableColumnVisibilityControl";
+import {
+  isColumnVisibilityPreference,
+  mergeColumnVisibility,
+  toPersistedColumnVisibility,
+} from "../utils/columnVisibility";
+import {
+  useDeletePreference,
+  usePreference,
+  useUpdatePreference,
+} from "@/hooks/use-preferences";
 
 export type { BulkEditField } from "@/components/bulk/BulkEditDialog";
 export { FilterType };
@@ -60,6 +80,7 @@ type DataTableProps<T> = {
     partial: Record<string, string | number>,
   ) => Promise<void>;
   filters?: FilterDef[];
+  tableId?: string;
 };
 
 export function DataTable<T>({
@@ -76,6 +97,7 @@ export function DataTable<T>({
   bulkEditFields,
   onBulkEdit,
   filters,
+  tableId,
 }: DataTableProps<T>) {
   const hasExpansion = !!(getSubRows || renderDetail);
 
@@ -95,20 +117,92 @@ export function DataTable<T>({
     defaultExpanded: defaultExpanded ?? (getSubRows ? true : {}),
   });
 
-  // React state: sorting, row selection, visibility, dialogs
-  const state = useDataTableState(columns, defaultSortColumn);
-
   // Prepare data
   const displayData = data ?? [];
   const enableRowSelection =
     onBulkDelete !== undefined || onBulkEdit !== undefined;
 
   // Process columns with selection and filters
-  const processedColumns = processColumnsWithFilters(
-    columns,
-    enableRowSelection,
-    filters,
+  const processedColumns = useMemo(
+    () => processColumnsWithFilters(columns, enableRowSelection, filters),
+    [columns, enableRowSelection, filters],
   );
+
+  // React state: sorting, row selection, visibility, dialogs
+  const state = useDataTableState(processedColumns, defaultSortColumn);
+  const { setColumnVisibility } = state;
+  const preferenceKey = tableId
+    ? `datatable.${tableId}.columnVisibility`
+    : null;
+  const columnPreference =
+    usePreference<Record<string, boolean>>(preferenceKey);
+  const updateColumnPreference = useUpdatePreference<Record<string, boolean>>();
+  const deleteColumnPreference = useDeletePreference();
+  const hasAppliedColumnPreference = useRef(!preferenceKey);
+
+  useEffect(() => {
+    if (!preferenceKey) {
+      hasAppliedColumnPreference.current = true;
+      return;
+    }
+    if (!columnPreference.isSuccess) return;
+
+    const savedVisibility = isColumnVisibilityPreference(
+      columnPreference.data?.value,
+    )
+      ? columnPreference.data.value
+      : undefined;
+    setColumnVisibility(
+      mergeColumnVisibility(processedColumns, savedVisibility),
+    );
+    hasAppliedColumnPreference.current = true;
+  }, [
+    columnPreference.data,
+    columnPreference.isSuccess,
+    preferenceKey,
+    processedColumns,
+    setColumnVisibility,
+  ]);
+
+  const saveColumnVisibility = useCallback(
+    (visibility: VisibilityState) => {
+      if (!preferenceKey || !hasAppliedColumnPreference.current) return;
+
+      updateColumnPreference.mutate({
+        key: preferenceKey,
+        value: toPersistedColumnVisibility(processedColumns, visibility),
+      });
+    },
+    [preferenceKey, processedColumns, updateColumnPreference],
+  );
+
+  const handleColumnVisibilityChange = useCallback(
+    (updater: Updater<VisibilityState>) => {
+      setColumnVisibility((previous) => {
+        const next =
+          typeof updater === "function" ? updater(previous) : updater;
+        const visibility = mergeColumnVisibility(processedColumns, next);
+        saveColumnVisibility(visibility);
+        return visibility;
+      });
+    },
+    [processedColumns, saveColumnVisibility, setColumnVisibility],
+  );
+
+  const resetColumnVisibility = useCallback(() => {
+    const visibility = mergeColumnVisibility(processedColumns);
+    setColumnVisibility(visibility);
+
+    if (preferenceKey) {
+      hasAppliedColumnPreference.current = true;
+      deleteColumnPreference.mutate(preferenceKey);
+    }
+  }, [
+    deleteColumnPreference,
+    preferenceKey,
+    processedColumns,
+    setColumnVisibility,
+  ]);
 
   // Create table instance
   // eslint-disable-next-line react-hooks/incompatible-library
@@ -124,9 +218,7 @@ export function DataTable<T>({
       ...(hasExpansion ? { expanded } : {}),
       ...(enableRowSelection ? { rowSelection: state.rowSelection } : {}),
     },
-    onColumnVisibilityChange: createTableStateUpdater(
-      state.setColumnVisibility,
-    ),
+    onColumnVisibilityChange: handleColumnVisibilityChange,
     ...(enableRowSelection
       ? {
           enableRowSelection: true,
@@ -197,6 +289,10 @@ export function DataTable<T>({
           ) : null}
         </div>
         <div className="flex items-center gap-2 sm:ml-auto">
+          <DataTableColumnVisibilityControl
+            table={table}
+            onReset={resetColumnVisibility}
+          />
           {buttons?.map((button, index) => (
             <Fragment key={index}>{button}</Fragment>
           ))}

--- a/apps/web/components/datatable/components/DataTableColumnVisibilityControl.tsx
+++ b/apps/web/components/datatable/components/DataTableColumnVisibilityControl.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { Table } from "@tanstack/react-table";
+import { Columns3, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { getColumnLabel, isColumnHideable } from "../utils/columnVisibility";
+
+type DataTableColumnVisibilityControlProps<T> = {
+  table: Table<T>;
+  onReset: () => void;
+};
+
+export function DataTableColumnVisibilityControl<T>({
+  table,
+  onReset,
+}: DataTableColumnVisibilityControlProps<T>) {
+  const columns = table.getAllLeafColumns().filter(isColumnHideable);
+
+  if (columns.length === 0) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          aria-label="Columns"
+          title="Columns"
+        >
+          <Columns3 className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Columns</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {columns.map((column) => (
+          <DropdownMenuCheckboxItem
+            key={column.id}
+            checked={column.getIsVisible()}
+            onCheckedChange={(checked) =>
+              column.toggleVisibility(checked === true)
+            }
+            onSelect={(event) => event.preventDefault()}
+          >
+            {getColumnLabel(column)}
+          </DropdownMenuCheckboxItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={onReset}>
+          <RotateCcw className="size-4" />
+          Reset
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/components/datatable/components/selection/selectionColumn.tsx
+++ b/apps/web/components/datatable/components/selection/selectionColumn.tsx
@@ -17,6 +17,8 @@ export function createSelectionColumn<T>(): ColumnDef<T> {
       </div>
     ),
     enableSorting: false,
+    enableHiding: false,
+    meta: { isSuppressed: true, isHideable: false },
     size: 50,
   };
 }

--- a/apps/web/components/datatable/hooks/useDataTableState.ts
+++ b/apps/web/components/datatable/hooks/useDataTableState.ts
@@ -8,6 +8,7 @@ import {
   RowSelectionState,
   Updater,
 } from "@tanstack/react-table";
+import { getDefaultColumnVisibility } from "../utils/columnVisibility";
 
 /**
  * Adapter function to convert React's setState to TanStack Table's OnChangeFn
@@ -54,17 +55,7 @@ export function useDataTableState<T>(
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(
-    () => {
-      const visibility: VisibilityState = {};
-      columns.forEach((col) => {
-        const colId = (col as any).id ?? (col as any).accessorKey;
-        const meta = (col as any).meta;
-        if (meta?.hidden) {
-          visibility[colId] = false;
-        }
-      });
-      return visibility;
-    },
+    () => getDefaultColumnVisibility(columns),
   );
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);

--- a/apps/web/components/datatable/utils/columnVisibility.ts
+++ b/apps/web/components/datatable/utils/columnVisibility.ts
@@ -1,0 +1,119 @@
+import type { Column, ColumnDef, VisibilityState } from "@tanstack/react-table";
+
+export type DataTableColumnMeta = {
+  label?: string;
+  hidden?: boolean;
+  isSuppressed?: boolean;
+  defaultVisible?: boolean;
+  isHideable?: boolean;
+  _hasExplicitSize?: boolean;
+};
+
+type ColumnWithIdentity<T> = ColumnDef<T> & {
+  id?: string;
+  accessorKey?: string;
+};
+
+export function getColumnId<T>(column: ColumnDef<T>): string | undefined {
+  const candidate = column as ColumnWithIdentity<T>;
+  return candidate.id ?? candidate.accessorKey;
+}
+
+export function getColumnMeta<T>(
+  column: ColumnDef<T>,
+): DataTableColumnMeta | undefined {
+  return column.meta as DataTableColumnMeta | undefined;
+}
+
+export function getDefaultColumnVisibility<T>(
+  columns: ColumnDef<T>[],
+): VisibilityState {
+  const visibility: VisibilityState = {};
+
+  columns.forEach((column) => {
+    const id = getColumnId(column);
+    if (!id) return;
+
+    const meta = getColumnMeta(column);
+    if (meta?.isSuppressed || meta?.hidden || meta?.defaultVisible === false) {
+      visibility[id] = false;
+    }
+
+    if (meta?.isHideable === false) {
+      delete visibility[id];
+    }
+  });
+
+  return visibility;
+}
+
+export function mergeColumnVisibility<T>(
+  columns: ColumnDef<T>[],
+  savedVisibility?: Record<string, boolean>,
+): VisibilityState {
+  const visibility = getDefaultColumnVisibility(columns);
+  const columnIds = new Set(columns.map(getColumnId).filter(Boolean));
+
+  Object.entries(savedVisibility ?? {}).forEach(([id, visible]) => {
+    if (!columnIds.has(id)) return;
+
+    const column = columns.find((candidate) => getColumnId(candidate) === id);
+    const meta = column ? getColumnMeta(column) : undefined;
+    if (meta?.isSuppressed || meta?.isHideable === false) return;
+
+    visibility[id] = visible;
+  });
+
+  return visibility;
+}
+
+export function toPersistedColumnVisibility<T>(
+  columns: ColumnDef<T>[],
+  visibility: VisibilityState,
+): Record<string, boolean> {
+  const persisted: Record<string, boolean> = {};
+
+  columns.forEach((column) => {
+    const id = getColumnId(column);
+    if (!id) return;
+
+    const meta = getColumnMeta(column);
+    if (meta?.isSuppressed || meta?.isHideable === false) return;
+
+    persisted[id] = visibility[id] ?? true;
+  });
+
+  return persisted;
+}
+
+export function isColumnVisibilityPreference(
+  value: unknown,
+): value is Record<string, boolean> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  return Object.values(value).every((visible) => typeof visible === "boolean");
+}
+
+export function isColumnSuppressed<T>(column: Column<T, unknown>) {
+  const meta = column.columnDef.meta as DataTableColumnMeta | undefined;
+  return meta?.isSuppressed === true || column.id === "select";
+}
+
+export function isColumnHideable<T>(column: Column<T, unknown>) {
+  const meta = column.columnDef.meta as DataTableColumnMeta | undefined;
+  return (
+    !isColumnSuppressed(column) &&
+    meta?.isHideable !== false &&
+    column.getCanHide()
+  );
+}
+
+export function getColumnLabel<T>(column: Column<T, unknown>) {
+  const meta = column.columnDef.meta as DataTableColumnMeta | undefined;
+  if (meta?.label) return meta.label;
+  if (typeof column.columnDef.header === "string")
+    return column.columnDef.header;
+  return column.id;
+}

--- a/apps/web/docs/features/datatable.md
+++ b/apps/web/docs/features/datatable.md
@@ -20,6 +20,10 @@ Some filters display options in groups. For example, the wines table groups wine
 
 Click any column header to sort by that column. Click again to reverse the sort order. A sort indicator appears next to the active column header.
 
+## Column Visibility
+
+Use the columns button above the table to choose which optional columns are visible. Primary columns and row action columns remain fixed. Column choices are saved to your user preferences for each table.
+
 ## Pagination
 
 Use the pagination controls at the bottom of the table to navigate between pages. The page size and current page are stored in the URL.

--- a/apps/web/hooks/use-preferences.ts
+++ b/apps/web/hooks/use-preferences.ts
@@ -1,0 +1,52 @@
+import { skipToken, useMutation, useQueryClient } from "@tanstack/react-query";
+import type { JsonValue } from "@cellarboss/types";
+import { useApiQuery } from "./use-api-query";
+import {
+  deletePreference,
+  getPreference,
+  updatePreference,
+} from "@/lib/api/preferences";
+
+export function preferenceQueryKey(key: string) {
+  return ["preferences", key] as const;
+}
+
+export function usePreference<TValue extends JsonValue = JsonValue>(
+  key: string | null,
+) {
+  return useApiQuery({
+    queryKey: key ? preferenceQueryKey(key) : ["preferences", "disabled"],
+    queryFn: key ? () => getPreference<TValue>(key) : skipToken,
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export function useUpdatePreference<TValue extends JsonValue = JsonValue>() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ key, value }: { key: string; value: TValue }) => {
+      const result = await updatePreference(key, value);
+      if (!result.ok) throw new Error(result.error.message);
+      return result.data;
+    },
+    onSuccess: (preference, { key }) => {
+      queryClient.setQueryData(preferenceQueryKey(key), preference);
+    },
+  });
+}
+
+export function useDeletePreference() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (key: string) => {
+      const result = await deletePreference(key);
+      if (!result.ok) throw new Error(result.error.message);
+      return result.data;
+    },
+    onSuccess: (_deleted, key) => {
+      queryClient.setQueryData(preferenceQueryKey(key), null);
+    },
+  });
+}

--- a/apps/web/lib/api/preferences.ts
+++ b/apps/web/lib/api/preferences.ts
@@ -1,0 +1,24 @@
+import type { JsonValue, UserPreference } from "@cellarboss/types";
+import { api } from "./client";
+import type { ApiResult } from "./types";
+
+export async function getPreference<TValue extends JsonValue = JsonValue>(
+  key: string,
+): Promise<ApiResult<UserPreference<TValue> | null>> {
+  const result = await api.preferences.get<TValue>(key);
+  if (!result.ok && result.error.status === 404) {
+    return { ok: true, data: null };
+  }
+  return result;
+}
+
+export function updatePreference<TValue extends JsonValue = JsonValue>(
+  key: string,
+  value: TValue,
+): Promise<ApiResult<UserPreference<TValue>>> {
+  return api.preferences.update(key, value);
+}
+
+export function deletePreference(key: string): Promise<ApiResult<boolean>> {
+  return api.preferences.delete(key);
+}

--- a/apps/web/lib/functions/__tests__/column-visibility.test.ts
+++ b/apps/web/lib/functions/__tests__/column-visibility.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  getDefaultColumnVisibility,
+  isColumnVisibilityPreference,
+  mergeColumnVisibility,
+  toPersistedColumnVisibility,
+} from "@/components/datatable/utils/columnVisibility";
+
+type Row = {
+  id: number;
+  name: string;
+  region: string;
+  country: string;
+};
+
+const columns: ColumnDef<Row>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+    meta: { isHideable: false },
+  },
+  {
+    accessorKey: "region",
+    header: "Region",
+  },
+  {
+    accessorKey: "country",
+    header: "Country",
+    meta: { defaultVisible: false },
+  },
+  {
+    id: "filterOnly",
+    header: "",
+    accessorFn: (row) => row.id,
+    meta: { isSuppressed: true, defaultVisible: false },
+  },
+];
+
+describe("column visibility helpers", () => {
+  it("builds defaults from column metadata", () => {
+    expect(getDefaultColumnVisibility(columns)).toEqual({
+      country: false,
+      filterOnly: false,
+    });
+  });
+
+  it("merges saved preferences without allowing fixed or suppressed overrides", () => {
+    expect(
+      mergeColumnVisibility(columns, {
+        name: false,
+        region: false,
+        country: true,
+        filterOnly: true,
+        unknown: false,
+      }),
+    ).toEqual({
+      region: false,
+      country: true,
+      filterOnly: false,
+    });
+  });
+
+  it("persists only user-hideable data columns", () => {
+    expect(
+      toPersistedColumnVisibility(columns, {
+        name: false,
+        region: false,
+        country: true,
+        filterOnly: true,
+      }),
+    ).toEqual({
+      region: false,
+      country: true,
+    });
+  });
+
+  it("validates preference payload shape", () => {
+    expect(isColumnVisibilityPreference({ name: true })).toBe(true);
+    expect(isColumnVisibilityPreference({ name: "true" })).toBe(false);
+    expect(isColumnVisibilityPreference(["name"])).toBe(false);
+  });
+});

--- a/packages/common/src/__tests__/api-client/client.test.ts
+++ b/packages/common/src/__tests__/api-client/client.test.ts
@@ -20,6 +20,7 @@ describe("createApiClient", () => {
     expect(client.winegrapes).toBeDefined();
     expect(client.tastingNotes).toBeDefined();
     expect(client.settings).toBeDefined();
+    expect(client.preferences).toBeDefined();
     expect(client.users).toBeDefined();
   });
 
@@ -36,6 +37,10 @@ describe("createApiClient", () => {
     expect(typeof client.settings.getAll).toBe("function");
     expect(typeof client.settings.getByKey).toBe("function");
     expect(typeof client.settings.update).toBe("function");
+
+    expect(typeof client.preferences.get).toBe("function");
+    expect(typeof client.preferences.update).toBe("function");
+    expect(typeof client.preferences.delete).toBe("function");
 
     expect(typeof client.winegrapes.getAll).toBe("function");
     expect(typeof client.winegrapes.getByWineId).toBe("function");

--- a/packages/common/src/__tests__/api-client/preferences.test.ts
+++ b/packages/common/src/__tests__/api-client/preferences.test.ts
@@ -49,4 +49,20 @@ describe("preferencesResource", () => {
     );
     expect(result).toEqual({ ok: true, data: true });
   });
+
+  it("delete passes through request errors", async () => {
+    const errorResponse = {
+      ok: false,
+      error: { message: "Not found", status: 404 },
+    } as const;
+    vi.mocked(mockRequest).mockResolvedValue(errorResponse);
+
+    const result = await preferences.delete("datatable.wines.columnVisibility");
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      "preferences/datatable.wines.columnVisibility",
+      "DELETE",
+    );
+    expect(result).toEqual(errorResponse);
+  });
 });

--- a/packages/common/src/__tests__/api-client/preferences.test.ts
+++ b/packages/common/src/__tests__/api-client/preferences.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { preferencesResource } from "../../resources/preferences";
+import type { RequestFn } from "../../types";
+
+describe("preferencesResource", () => {
+  const mockRequest = vi.fn() as unknown as RequestFn;
+  let preferences: ReturnType<typeof preferencesResource>;
+
+  beforeEach(() => {
+    vi.mocked(mockRequest).mockReset();
+    vi.mocked(mockRequest).mockResolvedValue({
+      ok: true,
+      data: { success: true },
+    });
+    preferences = preferencesResource(mockRequest);
+  });
+
+  it("get encodes the key in the path", async () => {
+    await preferences.get("datatable.wines.columnVisibility");
+    expect(mockRequest).toHaveBeenCalledWith(
+      "preferences/datatable.wines.columnVisibility",
+      "GET",
+    );
+  });
+
+  it("get encodes special characters", async () => {
+    await preferences.get("datatable:wines columns");
+    expect(mockRequest).toHaveBeenCalledWith(
+      "preferences/datatable%3Awines%20columns",
+      "GET",
+    );
+  });
+
+  it("update sends the JSON preference value", async () => {
+    const value = { name: true, region: false };
+    await preferences.update("datatable.wines.columnVisibility", value);
+    expect(mockRequest).toHaveBeenCalledWith(
+      "preferences/datatable.wines.columnVisibility",
+      "PUT",
+      JSON.stringify({ value }),
+    );
+  });
+
+  it("delete returns success as a boolean", async () => {
+    const result = await preferences.delete("datatable.wines.columnVisibility");
+    expect(mockRequest).toHaveBeenCalledWith(
+      "preferences/datatable.wines.columnVisibility",
+      "DELETE",
+    );
+    expect(result).toEqual({ ok: true, data: true });
+  });
+});

--- a/packages/common/src/client.ts
+++ b/packages/common/src/client.ts
@@ -14,6 +14,7 @@ import { settingsResource } from "./resources/settings";
 import { usersResource } from "./resources/users";
 import { versionResource } from "./resources/version";
 import { imagesResource } from "./resources/images";
+import { preferencesResource } from "./resources/preferences";
 
 export type ApiClientConfig = {
   request: RequestFn;
@@ -34,6 +35,7 @@ export function createApiClient(config: ApiClientConfig) {
     winegrapes: winegrapesResource(request),
     tastingNotes: tastingNotesResource(request),
     settings: settingsResource(request),
+    preferences: preferencesResource(request),
     users: usersResource(request),
     version: versionResource(request),
     images: imagesResource(request),

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -5,6 +5,12 @@ export { ApiQueryError } from "./types";
 export type { ApiError, ApiResult, RequestFn, UploadFn } from "./types";
 export { processBackendError } from "./errors";
 export type { AdminUser, UserFormData } from "./resources/users";
+export type {
+  JsonPrimitive,
+  JsonValue,
+  UserPreference,
+  UpsertUserPreference,
+} from "@cellarboss/types";
 
 // Constants
 export { WINE_TYPE_LABELS, BOTTLE_SIZE_LABELS } from "./constants";

--- a/packages/common/src/resources/preferences.ts
+++ b/packages/common/src/resources/preferences.ts
@@ -1,0 +1,39 @@
+import type {
+  JsonValue,
+  UpsertUserPreference,
+  UserPreference,
+} from "@cellarboss/types";
+import type { ApiResult, RequestFn } from "../types";
+
+export function preferencesResource(request: RequestFn) {
+  return {
+    get: <TValue extends JsonValue = JsonValue>(
+      key: string,
+    ): Promise<ApiResult<UserPreference<TValue>>> =>
+      request<UserPreference<TValue>>(
+        `preferences/${encodeURIComponent(key)}`,
+        "GET",
+      ),
+
+    update: <TValue extends JsonValue = JsonValue>(
+      key: string,
+      value: TValue,
+    ): Promise<ApiResult<UserPreference<TValue>>> => {
+      const body: UpsertUserPreference<TValue> = { value };
+      return request<UserPreference<TValue>>(
+        `preferences/${encodeURIComponent(key)}`,
+        "PUT",
+        JSON.stringify(body),
+      );
+    },
+
+    delete: (key: string): Promise<ApiResult<boolean>> =>
+      request<{ success: boolean }>(
+        `preferences/${encodeURIComponent(key)}`,
+        "DELETE",
+      ).then((result) => {
+        if (!result.ok) return result;
+        return { ok: true, data: result.data.success };
+      }),
+  };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -10,6 +10,8 @@ export type { Wine, CreateWine, UpdateWine } from "./wine";
 export type { WineGrape, CreateWineGrape, UpdateWineGrape } from "./winegrape";
 export type { WineMaker, CreateWineMaker, UpdateWineMaker } from "./winemaker";
 export type { Setting, UpdateSetting } from "./setting";
+export type { JsonPrimitive, JsonValue } from "./json";
+export type { UserPreference, UpsertUserPreference } from "./user-preference";
 export type {
   TastingNote,
   CreateTastingNote,

--- a/packages/types/src/json.ts
+++ b/packages/types/src/json.ts
@@ -1,0 +1,6 @@
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };

--- a/packages/types/src/user-preference.ts
+++ b/packages/types/src/user-preference.ts
@@ -1,0 +1,11 @@
+import type { JsonValue } from "./json";
+
+export interface UserPreference<TValue extends JsonValue = JsonValue> {
+  key: string;
+  value: TValue;
+}
+
+export type UpsertUserPreference<TValue extends JsonValue = JsonValue> = Pick<
+  UserPreference<TValue>,
+  "value"
+>;

--- a/packages/validators/src/__tests__/user-preferences.test.ts
+++ b/packages/validators/src/__tests__/user-preferences.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import {
+  upsertUserPreferenceSchema,
+  userPreferenceKeySchema,
+} from "../user-preferences.validator";
+
+describe("userPreferenceKeySchema", () => {
+  it("accepts namespaced keys", () => {
+    const result = userPreferenceKeySchema.safeParse(
+      "datatable.wines.columnVisibility",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects whitespace", () => {
+    const result = userPreferenceKeySchema.safeParse("datatable wines");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("upsertUserPreferenceSchema", () => {
+  it("accepts rich JSON values", () => {
+    const result = upsertUserPreferenceSchema.safeParse({
+      value: {
+        visible: { name: true, region: false },
+        pinned: ["name"],
+        compact: false,
+        empty: null,
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing values", () => {
+    const result = upsertUserPreferenceSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-JSON values", () => {
+    const result = upsertUserPreferenceSchema.safeParse({
+      value: { callback: () => true },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -12,5 +12,6 @@ export * from "./winegrapes.validator";
 export * from "./winemakers.validator";
 export * from "./wines.validator";
 export * from "./settings.validator";
+export * from "./user-preferences.validator";
 export * from "./tasting-notes.validator";
 export * from "./images.validator";

--- a/packages/validators/src/user-preferences.validator.ts
+++ b/packages/validators/src/user-preferences.validator.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import type { JsonValue } from "@cellarboss/types";
+
+export const userPreferenceKeySchema = z
+  .string()
+  .min(1)
+  .max(120)
+  .regex(/^[A-Za-z0-9._:-]+$/, {
+    message:
+      "Preference keys may only contain letters, numbers, dots, underscores, hyphens, and colons",
+  })
+  .describe("User preference key");
+
+export const jsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValueSchema),
+    z.record(z.string(), jsonValueSchema),
+  ]),
+);
+
+export const upsertUserPreferenceSchema = z.object({
+  value: jsonValueSchema.describe("JSON preference value"),
+});


### PR DESCRIPTION
Closes #363
Closes #364

## Summary
- add authenticated per-user preference API for JSON preference values
- add common/web preference client helpers
- add DataTable column chooser with fixed primary/action columns and suppressed filter-only columns
- persist column visibility per table using stable table IDs
- document the new column visibility control

## Verification
- pnpm --filter @cellarboss/validators test -- src/__tests__/user-preferences.test.ts
- pnpm --filter @cellarboss/common test -- src/__tests__/api-client/preferences.test.ts src/__tests__/api-client/client.test.ts
- pnpm --filter @cellarboss/backend test -- run src/tests/user-preferences.test.ts src/tests/settings.test.ts
- pnpm --filter @cellarboss/web test -- lib/functions/__tests__/column-visibility.test.ts
- pnpm --filter @cellarboss/web lint
- pnpm --filter @cellarboss/backend build
- pnpm --filter @cellarboss/web build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User Preferences API to save, retrieve and delete per-user JSON preferences; web hooks and client API added.
  * Data tables: per-table column visibility UI with persisted user preferences and a "Columns" control; stable table IDs supported.

* **Bug Fixes**
  * Settings endpoint no longer exposes user-specific preferences.

* **Documentation**
  * DataTable docs updated to describe column visibility and saved preferences.

* **Tests**
  * New test suites for the User Preferences API and column-visibility utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->