### PR TITLE
chore: Update actions/checkout to v6.0.3

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -4,11 +4,11 @@ on:
   workflow_call:
     inputs:
       detect-changes:
-        description: 'Run path-based change detection to conditionally skip unchanged test suites'
+        description: "Run path-based change detection to conditionally skip unchanged test suites"
         type: boolean
         default: false
       upload-coverage:
-        description: 'Run test:coverage instead of test and upload coverage artifacts'
+        description: "Run test:coverage instead of test and upload coverage artifacts"
         type: boolean
         default: false
 
@@ -26,7 +26,7 @@ jobs:
       packages: ${{ steps.filter.outputs.packages || 'true' }}
       structure: ${{ steps.filter.outputs.structure || 'true' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         if: inputs.detect-changes
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
@@ -55,7 +55,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Build frontend
@@ -83,7 +83,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Run validators unit tests
@@ -103,7 +103,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Run common unit tests
@@ -129,13 +129,13 @@ jobs:
         include:
           - db: sqlite
             DATABASE_TYPE: sqlite
-            DATABASE_URL: ':memory:'
+            DATABASE_URL: ":memory:"
           - db: postgres
             DATABASE_TYPE: postgres
-            DATABASE_URL: 'postgresql://cellar:cellar@localhost:5432/cellartest'
+            DATABASE_URL: "postgresql://cellar:cellar@localhost:5432/cellartest"
           - db: mysql
             DATABASE_TYPE: mysql
-            DATABASE_URL: 'mysql://cellar:cellar@localhost:3306/cellartest'
+            DATABASE_URL: "mysql://cellar:cellar@localhost:3306/cellartest"
 
     services:
       postgres:
@@ -167,7 +167,7 @@ jobs:
           --health-retries=10
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Build backend
@@ -196,7 +196,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Run mobile unit tests
@@ -216,7 +216,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Cache Playwright browsers
@@ -275,7 +275,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.structure == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Expo doctor
@@ -292,7 +292,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Validate API docs generation
@@ -304,7 +304,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.packages == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Build docs (without screenshots)
@@ -316,7 +316,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.packages == 'true'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Build docs (without screenshots)
@@ -339,16 +339,16 @@ jobs:
       - validate-mobile-docs
 
     steps:
-    - id: skips
-      run: |
-        echo "allowed=$(echo '${{ toJSON(needs) }}' | jq -r '
-        to_entries
-        | map(select(.value.result == "skipped"))
-        | map(.key)
-        | join(",")
-         ')" >> $GITHUB_OUTPUT
+      - id: skips
+        run: |
+          echo "allowed=$(echo '${{ toJSON(needs) }}' | jq -r '
+          to_entries
+          | map(select(.value.result == "skipped"))
+          | map(.key)
+          | join(",")
+           ')" >> $GITHUB_OUTPUT
 
-    - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
-        allowed-skips: ${{ steps.skips.outputs.allowed }}
+      - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+          allowed-skips: ${{ steps.skips.outputs.allowed }}

--- a/.github/workflows/expo-update.yml
+++ b/.github/workflows/expo-update.yml
@@ -2,7 +2,7 @@ name: Expo Auto Update
 
 on:
   schedule:
-    - cron: '0 */12 * * *'
+    - cron: "0 */12 * * *"
   workflow_dispatch:
 
 permissions:
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -2,7 +2,7 @@ name: PR Test Reports
 
 on:
   workflow_run:
-    workflows: ['PR Checks']
+    workflows: ["PR Checks"]
     types:
       - completed
 
@@ -17,7 +17,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Download web coverage
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.action != 'edited'
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Check formatting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - "v*.*.*"
 
 permissions:
   contents: write
@@ -16,7 +16,7 @@ jobs:
     name: Check Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Check formatting
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prettier, tests, smoketest-android]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Generate API docs
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prettier, tests, smoketest-android]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Cache Playwright browsers
@@ -98,14 +98,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prettier, tests, smoketest-android]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
@@ -267,14 +267,14 @@ jobs:
     needs: [prettier, tests, smoketest-android]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
@@ -344,7 +344,7 @@ jobs:
     needs: [docker-frontend, docker-backend, build-android]
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Download Android AAB
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -360,7 +360,7 @@ jobs:
         with:
           publish: true
           tag: ${{ github.ref_name }}
-          name: 'Release ${{ github.ref_name }}'
+          name: "Release ${{ github.ref_name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -376,7 +376,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -419,7 +419,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: '0 */2 * * *'
+    - cron: "0 */2 * * *"
   workflow_dispatch:
 
 permissions:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       - name: Renovate

--- a/.github/workflows/smoketest-android.yml
+++ b/.github/workflows/smoketest-android.yml
@@ -12,14 +12,14 @@ jobs:
     name: Android Smoke Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - uses: ./.github/actions/setup-node
 
       - name: Setup Java
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          distribution: "temurin"
+          java-version: "17"
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1


### PR DESCRIPTION
Refs #202

## Summary
- update pinned actions/checkout references from v6.0.2 to v6.0.3
- keep workflow YAML formatted with Prettier

## Verification
- git ls-remote --tags https://github.com/actions/checkout.git refs/tags/v6.0.3
- rg "actions/checkout@de0fac|v6\.0\.2|actions/checkout@9f698" .github/workflows -n
- pnpm exec prettier --check .github/workflows/ci-tests.yml .github/workflows/expo-update.yml .github/workflows/pr-report.yml .github/workflows/pr-validation.yml .github/workflows/release.yml .github/workflows/renovate.yml .github/workflows/smoketest-android.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD automation tooling to the latest stable versions across all workflows for improved reliability.
  * Standardised workflow configuration formatting to enhance consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->