### PR TITLE
chore: Update pnpm to 11.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "packageManager": "pnpm@11.5.0",
+  "packageManager": "pnpm@11.5.1",
   "scripts": {
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky"


### PR DESCRIPTION
Refs #202

## Summary
- update the root packageManager pin from pnpm 11.5.0 to 11.5.1
- leave the lockfile unchanged because the lockfile format and dependency graph are unchanged

## Verification
- npm view pnpm@11.5.1 version dist.integrity dist.tarball --json
- pnpm install --frozen-lockfile
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated project package manager to the latest minor release, incorporating stability improvements and maintenance updates for enhanced development tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->