### PR TITLE
feat: Add wine import from URL

### DIFF
--- a/apps/web/app/wines/import/page.tsx
+++ b/apps/web/app/wines/import/page.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import type {
+  Country,
+  Grape,
+  Region,
+  Wine,
+  WineMaker,
+} from "@cellarboss/types";
+import { LinkIcon } from "lucide-react";
+import * as z from "zod";
+import { PageHeader } from "@/components/page/PageHeader";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { GenericCard } from "@/components/cards/GenericCard";
+import { LoadingCard } from "@/components/cards/LoadingCard";
+import { ErrorCard } from "@/components/cards/ErrorCard";
+import { useApiQuery } from "@/hooks/use-api-query";
+import { queryGate } from "@/lib/functions/query-gate";
+import { getWinemakers } from "@/lib/api/winemakers";
+import { getRegions } from "@/lib/api/regions";
+import { getCountries } from "@/lib/api/countries";
+import { getGrapes } from "@/lib/api/grapes";
+import { createWinemaker } from "@/lib/api/winemakers";
+import { createRegion } from "@/lib/api/regions";
+import { createCountry } from "@/lib/api/countries";
+import { createGrape } from "@/lib/api/grapes";
+import { createWine } from "@/lib/api/wines";
+import { createWineGrape } from "@/lib/api/winegrapes";
+import { wineFields, type WineFormData } from "@/lib/fields/wines";
+import type { FieldConfig } from "@/lib/types/field";
+import {
+  buildWineImportDraft,
+  type ImportedWineDetails,
+} from "@/lib/import/wine-url";
+import { importWineFromUrl } from "@/lib/import/wine-url-action";
+import type { ApiError, ApiResult } from "@/lib/api/types";
+
+const wineImportFields: FieldConfig<WineFormData>[] = wineFields.map((field) =>
+  field.key === "wineMakerId"
+    ? {
+        ...field,
+        validator: z.preprocess(
+          (value) => (value === "" || value == null ? 0 : Number(value)),
+          z.number().int().min(0),
+        ) as FieldConfig<WineFormData>["validator"],
+      }
+    : field,
+);
+
+export default function ImportWinePage() {
+  const [url, setUrl] = useState("");
+  const [details, setDetails] = useState<ImportedWineDetails | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const winemakersQuery = useApiQuery({
+    queryKey: ["winemakers"],
+    queryFn: getWinemakers,
+  });
+  const regionsQuery = useApiQuery({
+    queryKey: ["regions"],
+    queryFn: getRegions,
+  });
+  const countriesQuery = useApiQuery({
+    queryKey: ["countries"],
+    queryFn: getCountries,
+  });
+  const grapesQuery = useApiQuery({ queryKey: ["grapes"], queryFn: getGrapes });
+
+  const result = queryGate([
+    winemakersQuery,
+    regionsQuery,
+    countriesQuery,
+    grapesQuery,
+  ]);
+
+  const draft = useMemo(() => {
+    if (!details || !result.ready) return null;
+    const [winemakers, regions, countries, grapes] = result.data;
+    return buildWineImportDraft(details, {
+      winemakers,
+      regions,
+      countries,
+      grapes,
+    });
+  }, [details, result]);
+
+  function handleImport() {
+    setErrorMessage(null);
+    setDetails(null);
+
+    startTransition(async () => {
+      const importResult = await importWineFromUrl(url);
+      if (!importResult.ok) {
+        setErrorMessage(importResult.error);
+        return;
+      }
+      setDetails(importResult.data);
+    });
+  }
+
+  async function handleCreate(
+    formData: WineFormData,
+  ): Promise<ApiResult<WineFormData>> {
+    if (!details || !draft) {
+      return importError("Import details are no longer available.");
+    }
+
+    const formValues = { ...formData };
+    delete (formValues as Partial<WineFormData>).id;
+    const { grapeIds, ...wineValues } = formValues;
+
+    let wineMakerId = Number(wineValues.wineMakerId);
+    if (!wineMakerId && details.winemakerName) {
+      const winemakerResult = await createWinemaker({
+        name: details.winemakerName,
+      } as WineMaker);
+      if (!winemakerResult.ok) {
+        return importError(
+          "Could not create imported winemaker.",
+          winemakerResult.error,
+        );
+      }
+      wineMakerId = winemakerResult.data.id;
+    }
+
+    if (!wineMakerId) {
+      return importError(
+        "A winemaker must be selected or detected before import.",
+      );
+    }
+
+    let regionId = wineValues.regionId ? Number(wineValues.regionId) : null;
+    if (!regionId && details.regionName) {
+      let countryId = draft.matches.country?.id;
+
+      if (!countryId && details.countryName) {
+        const countryResult = await createCountry({
+          name: details.countryName,
+        } as Country);
+        if (!countryResult.ok) {
+          return importError(
+            "Could not create imported country.",
+            countryResult.error,
+          );
+        }
+        countryId = countryResult.data.id;
+      }
+
+      if (countryId) {
+        const regionResult = await createRegion({
+          name: details.regionName,
+          countryId,
+        } as Region);
+        if (!regionResult.ok) {
+          return importError(
+            "Could not create imported region.",
+            regionResult.error,
+          );
+        }
+        regionId = regionResult.data.id;
+      }
+    }
+
+    const grapeIdSet = new Set(
+      (Array.isArray(grapeIds) ? grapeIds : []).map(Number).filter(Boolean),
+    );
+    for (const grapeName of draft.unmatched.grapeNames) {
+      const grapeResult = await createGrape({ name: grapeName } as Grape);
+      if (!grapeResult.ok) {
+        return importError(
+          "Could not create imported grape.",
+          grapeResult.error,
+        );
+      }
+      grapeIdSet.add(grapeResult.data.id);
+    }
+
+    const grapeIdList = [...grapeIdSet];
+    const result = await createWine({
+      name: wineValues.name,
+      type: wineValues.type,
+      wineMakerId,
+      regionId,
+    } as Wine);
+    if (!result.ok) return result;
+
+    const newWine = result.data;
+    for (const grapeId of grapeIdList) {
+      const grapeResult = await createWineGrape({
+        wineId: newWine.id,
+        grapeId,
+      });
+      if (!grapeResult.ok) {
+        return { ok: false, error: grapeResult.error };
+      }
+    }
+
+    return { ok: true, data: { ...newWine, grapeIds: grapeIdList } };
+  }
+
+  if (!result.ready) {
+    return result.gate;
+  }
+
+  return (
+    <section>
+      <PageHeader title="Import Wine" />
+
+      <Card className="max-w-2xl">
+        <CardHeader>
+          <CardTitle>Source URL</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Input
+              type="url"
+              value={url}
+              onChange={(event) => setUrl(event.target.value)}
+              placeholder="https://example.com/wines/example-wine"
+              aria-label="Wine page URL"
+            />
+            <Button
+              type="button"
+              onClick={handleImport}
+              disabled={isPending || !url.trim()}
+            >
+              <LinkIcon />
+              {isPending ? "Importing..." : "Import"}
+            </Button>
+          </div>
+
+          {errorMessage && (
+            <div className="text-sm text-red-600">{errorMessage}</div>
+          )}
+        </CardContent>
+      </Card>
+
+      {isPending && <LoadingCard />}
+
+      {details && draft && (
+        <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,28rem)_minmax(0,1fr)]">
+          <ImportSummary details={details} draft={draft} />
+          <GenericCard<WineFormData>
+            key={details.sourceUrl}
+            mode="create"
+            data={draft.data as WineFormData}
+            fields={wineImportFields}
+            processSave={handleCreate}
+            redirectTo="/wines"
+          />
+        </div>
+      )}
+
+      {details && !draft && (
+        <ErrorCard message="Could not prepare import draft." />
+      )}
+    </section>
+  );
+}
+
+function ImportSummary({
+  details,
+  draft,
+}: {
+  details: ImportedWineDetails;
+  draft: ReturnType<typeof buildWineImportDraft>;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Import Draft</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <SummaryRow label="Name" value={details.name} />
+        <SummaryRow label="Type" value={details.type} />
+        <SummaryRow
+          label="Vintage"
+          value={details.vintageYear ? String(details.vintageYear) : null}
+        />
+        <MatchRow
+          label="Winemaker"
+          matched={draft.matches.winemaker?.name}
+          unmatched={draft.unmatched.winemakerName}
+        />
+        <MatchRow
+          label="Region"
+          matched={draft.matches.region?.name}
+          unmatched={draft.unmatched.regionName}
+        />
+        <MatchRow
+          label="Country"
+          matched={draft.matches.country?.name}
+          unmatched={draft.unmatched.countryName}
+        />
+        <div className="space-y-2">
+          <div className="text-sm font-medium">Grapes</div>
+          <div className="flex flex-wrap gap-2">
+            {draft.matches.grapes.map((grape) => (
+              <Badge key={grape.id} variant="secondary">
+                {grape.name}
+              </Badge>
+            ))}
+            {draft.unmatched.grapeNames.map((grapeName) => (
+              <Badge key={grapeName} variant="outline">
+                New: {grapeName}
+              </Badge>
+            ))}
+            {!draft.matches.grapes.length &&
+              !draft.unmatched.grapeNames.length && (
+                <span className="text-sm text-muted-foreground">
+                  None detected
+                </span>
+              )}
+          </div>
+        </div>
+        {details.sourceTitle && (
+          <SummaryRow label="Page title" value={details.sourceTitle} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SummaryRow({ label, value }: { label: string; value: string | null }) {
+  return (
+    <div className="space-y-1">
+      <div className="text-sm font-medium">{label}</div>
+      <div className="text-sm text-muted-foreground">
+        {value ?? "Not detected"}
+      </div>
+    </div>
+  );
+}
+
+function MatchRow({
+  label,
+  matched,
+  unmatched,
+}: {
+  label: string;
+  matched?: string;
+  unmatched: string | null;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="text-sm font-medium">{label}</div>
+      {matched ? (
+        <Badge variant="secondary">{matched}</Badge>
+      ) : unmatched ? (
+        <Badge variant="outline">New: {unmatched}</Badge>
+      ) : (
+        <span className="text-sm text-muted-foreground">Not detected</span>
+      )}
+    </div>
+  );
+}
+
+function importError(
+  message: string,
+  cause?: ApiError,
+): ApiResult<WineFormData> {
+  return {
+    ok: false,
+    error: {
+      message,
+      errors: cause?.errors ?? {},
+      status: cause?.status ?? 400,
+    },
+  };
+}

--- a/apps/web/app/wines/new/page.tsx
+++ b/apps/web/app/wines/new/page.tsx
@@ -9,8 +9,12 @@ import { createWineGrape } from "@/lib/api/winegrapes";
 import { ApiResult } from "@/lib/api/types";
 import { PageHeader } from "@/components/page/PageHeader";
 
-async function handleCreate(formData: any): Promise<ApiResult<WineFormData>> {
-  const { grapeIds, ...wineData } = formData;
+async function handleCreate(
+  formData: WineFormData,
+): Promise<ApiResult<WineFormData>> {
+  const formValues = { ...formData };
+  delete (formValues as Partial<WineFormData>).id;
+  const { grapeIds, ...wineData } = formValues;
 
   const result = await createWine(wineData as Wine);
   if (!result.ok) return result;
@@ -18,18 +22,18 @@ async function handleCreate(formData: any): Promise<ApiResult<WineFormData>> {
   const newWine = result.data;
 
   // Create winegrape associations
-  const grapeIdList: string[] = Array.isArray(grapeIds) ? grapeIds : [];
+  const grapeIdList = Array.isArray(grapeIds) ? grapeIds.map(Number) : [];
   for (const grapeId of grapeIdList) {
     const grapeResult = await createWineGrape({
       wineId: newWine.id,
-      grapeId: Number(grapeId),
+      grapeId,
     });
     if (!grapeResult.ok) {
       return { ok: false, error: grapeResult.error };
     }
   }
 
-  return { ok: true, data: { ...newWine, grapeIds: grapeIdList.map(Number) } };
+  return { ok: true, data: { ...newWine, grapeIds: grapeIdList } };
 }
 
 export default function NewWinePage() {

--- a/apps/web/app/wines/page.tsx
+++ b/apps/web/app/wines/page.tsx
@@ -29,6 +29,8 @@ import { VintageButton } from "@/components/buttons/VintageButton";
 import { WINE_TYPES } from "@cellarboss/validators/constants";
 import { WineTastingNotesButton } from "@/components/buttons/TastingNotesButton";
 import { formatWineType } from "@/lib/functions/format";
+import { LinkIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 export default function WinesPage() {
   const queryClient = useQueryClient();
@@ -303,6 +305,16 @@ export default function WinesPage() {
             subject="Wine"
             key="add"
           />,
+          <Button
+            key="import"
+            size="lg"
+            variant="outline"
+            onClick={() => router.push("/wines/import")}
+            className="cursor-pointer"
+          >
+            <LinkIcon />
+            Import from URL
+          </Button>,
         ]}
       />
     </section>

--- a/apps/web/lib/import/__tests__/wine-url.test.ts
+++ b/apps/web/lib/import/__tests__/wine-url.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { buildWineImportDraft, extractWineDetailsFromHtml } from "../wine-url";
+
+describe("extractWineDetailsFromHtml", () => {
+  it("extracts wine details from JSON-LD product data", () => {
+    const html = `
+      <html>
+        <head>
+          <title>Example Cellars Cabernet Sauvignon 2024 | Shop</title>
+          <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "Product",
+              "name": "Example Cellars Reserve Cabernet Sauvignon 2024",
+              "description": "A red wine from Napa Valley, United States.",
+              "brand": { "name": "Example Cellars" },
+              "productionPlace": {
+                "name": "Napa Valley",
+                "address": {
+                  "addressRegion": "Napa Valley",
+                  "addressCountry": "United States"
+                }
+              }
+            }
+          </script>
+        </head>
+      </html>
+    `;
+
+    const result = extractWineDetailsFromHtml(html, "https://example.com/wine");
+
+    expect(result).toMatchObject({
+      name: "Example Cellars Reserve Cabernet Sauvignon",
+      type: "red",
+      vintageYear: 2024,
+      winemakerName: "Example Cellars",
+      regionName: "Napa Valley",
+      countryName: "United States",
+      grapeNames: ["Cabernet Sauvignon"],
+    });
+  });
+
+  it("falls back to metadata when JSON-LD is absent", () => {
+    const html = `
+      <html>
+        <head>
+          <meta property="og:title" content="Chateau Example Rosé 2023 - Wine Shop" />
+          <meta property="og:description" content="Rosé wine made with Grenache." />
+        </head>
+      </html>
+    `;
+
+    const result = extractWineDetailsFromHtml(html, "https://example.com/rose");
+
+    expect(result.name).toBe("Chateau Example Rosé");
+    expect(result.type).toBe("rose");
+    expect(result.vintageYear).toBe(2023);
+    expect(result.grapeNames).toEqual(["Grenache"]);
+  });
+});
+
+describe("buildWineImportDraft", () => {
+  it("matches extracted resources against existing CellarBoss data", () => {
+    const draft = buildWineImportDraft(
+      {
+        sourceUrl: "https://example.com/wine",
+        sourceTitle: "Example wine",
+        name: "Reserve Cabernet Sauvignon",
+        type: "red",
+        vintageYear: 2024,
+        winemakerName: "Example Cellars",
+        regionName: "Napa Valley",
+        countryName: "United States",
+        grapeNames: ["Cabernet Sauvignon", "Merlot"],
+      },
+      {
+        winemakers: [{ id: 1, name: "Example Cellars" }],
+        countries: [{ id: 2, name: "United States" }],
+        regions: [{ id: 3, name: "Napa Valley", countryId: 2 }],
+        grapes: [{ id: 4, name: "Cabernet Sauvignon" }],
+      },
+    );
+
+    expect(draft.data).toMatchObject({
+      name: "Reserve Cabernet Sauvignon",
+      type: "red",
+      wineMakerId: 1,
+      regionId: 3,
+      grapeIds: [4],
+    });
+    expect(draft.unmatched.grapeNames).toEqual(["Merlot"]);
+  });
+});

--- a/apps/web/lib/import/wine-url-action.ts
+++ b/apps/web/lib/import/wine-url-action.ts
@@ -1,0 +1,169 @@
+"use server";
+
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import { extractWineDetailsFromHtml } from "./wine-url";
+
+const MAX_REDIRECTS = 3;
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const REQUEST_TIMEOUT_MS = 12_000;
+
+export type WineUrlImportResult =
+  | { ok: true; data: ReturnType<typeof extractWineDetailsFromHtml> }
+  | { ok: false; error: string };
+
+export async function importWineFromUrl(
+  inputUrl: string,
+): Promise<WineUrlImportResult> {
+  let currentUrl: URL;
+
+  try {
+    currentUrl = new URL(inputUrl);
+  } catch {
+    return { ok: false, error: "Enter a valid URL." };
+  }
+
+  for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+    const validation = await validatePublicHttpUrl(currentUrl);
+    if (!validation.ok) {
+      return { ok: false, error: validation.error };
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(currentUrl, {
+        redirect: "manual",
+        signal: controller.signal,
+        headers: {
+          Accept: "text/html,application/xhtml+xml",
+          "User-Agent": "CellarBoss-Wine-Importer/1.0",
+        },
+      });
+
+      if (isRedirect(response.status)) {
+        const location = response.headers.get("location");
+        if (!location) {
+          return { ok: false, error: "The URL redirected without a location." };
+        }
+        currentUrl = new URL(location, currentUrl);
+        continue;
+      }
+
+      if (!response.ok) {
+        return {
+          ok: false,
+          error: `The page returned HTTP ${response.status}.`,
+        };
+      }
+
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.toLowerCase().includes("text/html")) {
+        return { ok: false, error: "The URL did not return an HTML page." };
+      }
+
+      const html = await readLimitedResponse(response);
+      return {
+        ok: true,
+        data: extractWineDetailsFromHtml(html, currentUrl.toString()),
+      };
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        return { ok: false, error: "The page took too long to respond." };
+      }
+      return { ok: false, error: "Could not import details from that URL." };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  return { ok: false, error: "The URL redirected too many times." };
+}
+
+async function readLimitedResponse(response: Response): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return response.text();
+  }
+
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+
+    totalBytes += value.byteLength;
+    if (totalBytes > MAX_RESPONSE_BYTES) {
+      throw new Error("Response body is too large.");
+    }
+    chunks.push(value);
+  }
+
+  return new TextDecoder().decode(Buffer.concat(chunks));
+}
+
+async function validatePublicHttpUrl(
+  url: URL,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return { ok: false, error: "Only HTTP and HTTPS URLs can be imported." };
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname === "0.0.0.0"
+  ) {
+    return { ok: false, error: "Local URLs cannot be imported." };
+  }
+
+  if (isPrivateAddress(hostname)) {
+    return { ok: false, error: "Private network URLs cannot be imported." };
+  }
+
+  const addresses = await lookup(hostname, { all: true, verbatim: false });
+  if (
+    !addresses.length ||
+    addresses.some((address) => isPrivateAddress(address.address))
+  ) {
+    return { ok: false, error: "Private network URLs cannot be imported." };
+  }
+
+  return { ok: true };
+}
+
+function isRedirect(status: number): boolean {
+  return status >= 300 && status < 400;
+}
+
+function isPrivateAddress(address: string): boolean {
+  const ipVersion = isIP(address);
+
+  if (ipVersion === 4) {
+    const [a = 0, b = 0] = address.split(".").map(Number);
+    return (
+      a === 10 ||
+      a === 127 ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 168) ||
+      a === 0
+    );
+  }
+
+  if (ipVersion === 6) {
+    const normalized = address.toLowerCase();
+    return (
+      normalized === "::1" ||
+      normalized.startsWith("fc") ||
+      normalized.startsWith("fd") ||
+      normalized.startsWith("fe80:")
+    );
+  }
+
+  return false;
+}

--- a/apps/web/lib/import/wine-url.ts
+++ b/apps/web/lib/import/wine-url.ts
@@ -1,0 +1,396 @@
+import { WINE_TYPES, type WineType } from "@cellarboss/validators/constants";
+
+export type ImportedWineDetails = {
+  sourceUrl: string;
+  sourceTitle: string | null;
+  name: string | null;
+  type: WineType | null;
+  vintageYear: number | null;
+  winemakerName: string | null;
+  regionName: string | null;
+  countryName: string | null;
+  grapeNames: string[];
+};
+
+type JsonLdNode = Record<string, unknown>;
+
+const COMMON_GRAPE_NAMES = [
+  "Cabernet Sauvignon",
+  "Merlot",
+  "Pinot Noir",
+  "Chardonnay",
+  "Sauvignon Blanc",
+  "Riesling",
+  "Syrah",
+  "Shiraz",
+  "Sangiovese",
+  "Malbec",
+  "Tempranillo",
+  "Grenache",
+  "Nebbiolo",
+  "Pinot Grigio",
+  "Pinot Gris",
+  "Chenin Blanc",
+  "Zinfandel",
+  "Viognier",
+  "Gamay",
+  "Mourvedre",
+  "Mourvèdre",
+  "Gewurztraminer",
+  "Gewürztraminer",
+] as const;
+
+export function extractWineDetailsFromHtml(
+  html: string,
+  sourceUrl: string,
+): ImportedWineDetails {
+  const metadata = extractMetadata(html);
+  const jsonLdNodes = extractJsonLdNodes(html);
+  const wineNode = findWineNode(jsonLdNodes);
+
+  const title = firstText(
+    getPath(wineNode, ["name"]),
+    metadata["og:title"],
+    metadata["twitter:title"],
+    metadata.title,
+  );
+  const description = firstText(
+    getPath(wineNode, ["description"]),
+    metadata["og:description"],
+    metadata.description,
+  );
+  const combinedText = [title, description, sourceUrl]
+    .filter(Boolean)
+    .join(" ");
+
+  const rawName = firstText(
+    getPath(wineNode, ["name"]),
+    metadata["og:title"],
+    metadata["twitter:title"],
+    metadata.title,
+  );
+  const sourceTitle = cleanText(metadata["og:title"] ?? metadata.title ?? null);
+
+  return {
+    sourceUrl,
+    sourceTitle,
+    name: cleanWineName(rawName, sourceTitle),
+    type: detectWineType(combinedText),
+    vintageYear: extractVintageYear(combinedText),
+    winemakerName: firstText(
+      getPath(wineNode, ["brand", "name"]),
+      getPath(wineNode, ["manufacturer", "name"]),
+      getPath(wineNode, ["producer", "name"]),
+      getPath(wineNode, ["creator", "name"]),
+      getPath(wineNode, ["seller", "name"]),
+    ),
+    regionName: firstText(
+      getPath(wineNode, ["productionPlace", "address", "addressRegion"]),
+      getPath(wineNode, ["productionPlace", "name"]),
+      getPath(wineNode, ["originAddress", "addressRegion"]),
+      getPath(wineNode, ["address", "addressRegion"]),
+      getPath(wineNode, ["appellation"]),
+    ),
+    countryName: firstText(
+      getPath(wineNode, ["countryOfOrigin", "name"]),
+      getPath(wineNode, ["productionPlace", "address", "addressCountry"]),
+      getPath(wineNode, ["originAddress", "addressCountry"]),
+      getPath(wineNode, ["address", "addressCountry"]),
+    ),
+    grapeNames: extractGrapeNames(wineNode, combinedText),
+  };
+}
+
+export function buildWineImportDraft<T extends { id: number; name: string }>(
+  details: ImportedWineDetails,
+  resources: {
+    winemakers: T[];
+    regions: (T & { countryId?: number })[];
+    countries: T[];
+    grapes: T[];
+  },
+) {
+  const country = matchByName(resources.countries, details.countryName);
+  const region = matchByName(resources.regions, details.regionName, {
+    countryId: country?.id,
+  });
+  const winemaker = matchByName(resources.winemakers, details.winemakerName);
+  const grapes = details.grapeNames
+    .map((name) => matchByName(resources.grapes, name))
+    .filter((grape): grape is T => Boolean(grape));
+
+  return {
+    data: {
+      id: 0,
+      name: details.name ?? "",
+      type: details.type ?? "red",
+      wineMakerId: winemaker?.id ?? "",
+      regionId: region?.id ?? "",
+      grapeIds: grapes.map((grape) => grape.id),
+    },
+    matches: {
+      country,
+      region,
+      winemaker,
+      grapes,
+    },
+    unmatched: {
+      countryName: details.countryName && !country ? details.countryName : null,
+      regionName: details.regionName && !region ? details.regionName : null,
+      winemakerName:
+        details.winemakerName && !winemaker ? details.winemakerName : null,
+      grapeNames: details.grapeNames.filter(
+        (name) =>
+          !resources.grapes.some((grape) => isNameMatch(grape.name, name)),
+      ),
+    },
+  };
+}
+
+function extractMetadata(html: string): Record<string, string> {
+  const metadata: Record<string, string> = {};
+  const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (titleMatch?.[1]) {
+    metadata.title = decodeHtml(titleMatch[1]);
+  }
+
+  const metaRegex = /<meta\b([^>]*)>/gi;
+  let match: RegExpExecArray | null;
+  while ((match = metaRegex.exec(html))) {
+    const attrs = parseAttributes(match[1] ?? "");
+    const key = attrs.property ?? attrs.name;
+    const content = attrs.content;
+    if (key && content) {
+      metadata[key.toLowerCase()] = decodeHtml(content);
+    }
+  }
+
+  return metadata;
+}
+
+function parseAttributes(input: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const attrRegex = /([a-zA-Z_:.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g;
+  let match: RegExpExecArray | null;
+  while ((match = attrRegex.exec(input))) {
+    const key = match[1]?.toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4];
+    if (key && value) {
+      attrs[key] = value;
+    }
+  }
+  return attrs;
+}
+
+function extractJsonLdNodes(html: string): JsonLdNode[] {
+  const nodes: JsonLdNode[] = [];
+  const scriptRegex =
+    /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = scriptRegex.exec(html))) {
+    const scriptBody = decodeHtml(match[1] ?? "").trim();
+    if (!scriptBody) continue;
+
+    try {
+      flattenJsonLd(JSON.parse(scriptBody), nodes);
+    } catch {
+      continue;
+    }
+  }
+
+  return nodes;
+}
+
+function flattenJsonLd(value: unknown, nodes: JsonLdNode[]) {
+  if (Array.isArray(value)) {
+    value.forEach((item) => flattenJsonLd(item, nodes));
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  nodes.push(value);
+
+  const graph = value["@graph"];
+  if (Array.isArray(graph)) {
+    graph.forEach((item) => flattenJsonLd(item, nodes));
+  }
+}
+
+function findWineNode(nodes: JsonLdNode[]): JsonLdNode | undefined {
+  return (
+    nodes.find((node) => hasType(node, "Wine")) ??
+    nodes.find((node) => hasType(node, "Product")) ??
+    nodes.find((node) => typeof node.name === "string")
+  );
+}
+
+function hasType(node: JsonLdNode, type: string): boolean {
+  const rawType = node["@type"];
+  if (Array.isArray(rawType)) {
+    return rawType.some(
+      (value) => String(value).toLowerCase() === type.toLowerCase(),
+    );
+  }
+  return String(rawType).toLowerCase() === type.toLowerCase();
+}
+
+function getPath(source: unknown, path: string[]): unknown {
+  let current = source;
+  for (const key of path) {
+    if (!isRecord(current)) return undefined;
+    current = current[key];
+  }
+  return current;
+}
+
+function firstText(...values: unknown[]): string | null {
+  for (const value of values) {
+    const text = normalizeText(value);
+    if (text) return text;
+  }
+  return null;
+}
+
+function normalizeText(value: unknown): string | null {
+  if (typeof value === "string") {
+    return cleanText(value);
+  }
+  if (Array.isArray(value)) {
+    return firstText(...value);
+  }
+  if (isRecord(value)) {
+    return firstText(value.name, value.value, value.text);
+  }
+  return null;
+}
+
+function cleanText(value: string | null): string | null {
+  const cleaned = value
+    ?.replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned || null;
+}
+
+function cleanWineName(
+  rawName: string | null,
+  sourceTitle: string | null,
+): string | null {
+  const fallback = rawName ?? sourceTitle;
+  if (!fallback) return null;
+
+  const withoutSite = fallback
+    .split(/\s+[|–-]\s+/)[0]
+    .replace(/\b(19|20)\d{2}\b/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return withoutSite || fallback;
+}
+
+function detectWineType(input: string): WineType | null {
+  const text = input.toLowerCase();
+  const checks: Array<[WineType, RegExp]> = [
+    ["sparkling", /\b(sparkling|champagne|prosecco|cava)\b/],
+    ["fortified", /\b(fortified|port|sherry|madeira)\b/],
+    ["dessert", /\b(dessert|sauternes|ice wine|late harvest)\b/],
+    ["orange", /\borange wine\b/],
+    ["rose", /\b(rosé|rose wine|rose)\b/],
+    ["white", /\b(white wine|white)\b/],
+    ["red", /\b(red wine|red)\b/],
+  ];
+
+  return checks.find(([, pattern]) => pattern.test(text))?.[0] ?? null;
+}
+
+function extractVintageYear(input: string): number | null {
+  const match = input.match(/\b(19[5-9]\d|20\d{2})\b/);
+  return match?.[1] ? Number(match[1]) : null;
+}
+
+function extractGrapeNames(node: JsonLdNode | undefined, fallbackText: string) {
+  const candidates = [
+    getPath(node, ["varietal"]),
+    getPath(node, ["variety"]),
+    getPath(node, ["grape"]),
+    getPath(node, ["material"]),
+    getPath(node, ["category"]),
+    getPath(node, ["additionalProperty"]),
+    fallbackText,
+  ];
+
+  const combined = candidates
+    .map((candidate) => JSON.stringify(candidate))
+    .filter(Boolean)
+    .join(" ");
+
+  return COMMON_GRAPE_NAMES.filter((grape) =>
+    new RegExp(`\\b${escapeRegex(grape)}\\b`, "i").test(combined),
+  );
+}
+
+function matchByName<T extends { id: number; name: string }>(
+  resources: T[],
+  name: string | null,
+  constraints?: { countryId?: number },
+): T | undefined {
+  if (!name) return undefined;
+  return resources.find((resource) => {
+    if (
+      constraints?.countryId &&
+      "countryId" in resource &&
+      resource.countryId !== constraints.countryId
+    ) {
+      return false;
+    }
+    return isNameMatch(resource.name, name);
+  });
+}
+
+function isNameMatch(left: string, right: string): boolean {
+  const normalizedLeft = normalizeName(left);
+  const normalizedRight = normalizeName(right);
+  return (
+    normalizedLeft === normalizedRight ||
+    normalizedLeft.includes(normalizedRight) ||
+    normalizedRight.includes(normalizedLeft)
+  );
+}
+
+function normalizeName(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/gi, " ")
+    .replace(/\b(the|wine|wines|winery|vineyard|vineyards)\b/gi, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function decodeHtml(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isRecord(value: unknown): value is JsonLdNode {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isSupportedWineType(value: string): value is WineType {
+  return WINE_TYPES.includes(value as WineType);
+}


### PR DESCRIPTION
## Summary
- add a web-only wine import flow at `/wines/import` and link it from the Wines toolbar
- scrape JSON-LD and page metadata for wine name, type, vintage, producer, region, country, and grapes
- match scraped values to existing CellarBoss resources, preview unmatched values, and create detected missing reference data on submit
- add URL safety checks before server-side fetching to reject local/private network targets

Closes #281

## Validation
- `pnpm --filter @cellarboss/web test -- lib/import/__tests__/wine-url.test.ts`
- `pnpm --filter @cellarboss/web lint`
- `pnpm --filter @cellarboss/web build`
- `pnpm exec prettier --check apps/web/lib/import/wine-url.ts apps/web/lib/import/wine-url-action.ts apps/web/app/wines/import/page.tsx apps/web/app/wines/page.tsx apps/web/app/wines/new/page.tsx apps/web/lib/import/__tests__/wine-url.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added wine import functionality allowing users to import wines directly from external URLs
  * New "Import from URL" button on the wines page for convenient access to the import workflow
  * Import page guides users through URL validation, reference data matching, and wine creation

* **Tests**
  * Added unit tests for wine URL extraction and import draft functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->