### PR TITLE
feat: Add frontend internationalisation foundation

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/(more)/more.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/(more)/more.tsx
@@ -5,28 +5,37 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useAuth } from "@/contexts/auth-context";
 import { useThemePreference } from "@/contexts/theme-context";
+import { useI18n } from "@/contexts/i18n-context";
 import { useAppTheme } from "@/hooks/use-app-theme";
 import { useApiQuery } from "@/hooks/use-api-query";
+import { useUpdateSetting } from "@/hooks/use-settings";
 import { api } from "@/lib/api/client";
 import { getApiBaseUrl } from "@/lib/api/base-url";
 import type { ThemePreference } from "@/lib/auth/secure-store";
 import * as Application from "expo-application";
-
-const themeLabels: Record<ThemePreference, string> = {
-  light: "Light",
-  dark: "Dark",
-  system: "System default",
-};
+import {
+  getLanguageLabel,
+  SUPPORTED_LANGUAGE_OPTIONS,
+} from "@cellarboss/common/i18n";
 
 export default function MoreScreen() {
   const router = useRouter();
   const auth = useAuth();
   const theme = useAppTheme();
   const { preference, setPreference } = useThemePreference();
+  const { language, t } = useI18n();
+  const updateSetting = useUpdateSetting();
   const user = auth.status === "authenticated" ? auth.user : null;
+  const isAdmin = user?.role === "admin";
   const styles = useStyles();
   const [apiBaseUrl, setApiBaseUrl] = useState<string | null>(null);
   const [themeDialogVisible, setThemeDialogVisible] = useState(false);
+  const [languageDialogVisible, setLanguageDialogVisible] = useState(false);
+  const themeLabels: Record<ThemePreference, string> = {
+    light: t("theme.light"),
+    dark: t("theme.dark"),
+    system: t("theme.system"),
+  };
 
   useEffect(() => {
     getApiBaseUrl().then(setApiBaseUrl);
@@ -41,10 +50,10 @@ export default function MoreScreen() {
     <SafeAreaView style={styles.container} edges={["top"]}>
       <ScrollView>
         <List.Section>
-          <List.Subheader>Wine Data</List.Subheader>
+          <List.Subheader>{t("section.wineData")}</List.Subheader>
           <List.Item
             testID="menu-cellar"
-            title="Cellar"
+            title={t("nav.cellar")}
             left={(props) => (
               <List.Icon {...props} icon="bottle-wine-outline" />
             )}
@@ -53,14 +62,14 @@ export default function MoreScreen() {
           />
           <List.Item
             testID="menu-wines"
-            title="Wines"
+            title={t("nav.wines")}
             left={(props) => <List.Icon {...props} icon="glass-wine" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
             onPress={() => router.push("/wines")}
           />
           <List.Item
             testID="menu-tasting-notes"
-            title="Tasting Notes"
+            title={t("nav.tastingNotes")}
             left={(props) => <List.Icon {...props} icon="note-text-outline" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
             onPress={() => router.push("/tasting-notes")}
@@ -70,10 +79,10 @@ export default function MoreScreen() {
         <Divider />
 
         <List.Section>
-          <List.Subheader>Reference Data</List.Subheader>
+          <List.Subheader>{t("section.referenceData")}</List.Subheader>
           <List.Item
             testID="menu-winemakers"
-            title="Winemakers"
+            title={t("nav.winemakers")}
             left={(props) => (
               <List.Icon {...props} icon="account-group-outline" />
             )}
@@ -82,21 +91,21 @@ export default function MoreScreen() {
           />
           <List.Item
             testID="menu-regions"
-            title="Regions"
+            title={t("nav.regions")}
             left={(props) => <List.Icon {...props} icon="map-marker-outline" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
             onPress={() => router.push("/regions")}
           />
           <List.Item
             testID="menu-countries"
-            title="Countries"
+            title={t("nav.countries")}
             left={(props) => <List.Icon {...props} icon="earth" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
             onPress={() => router.push("/countries")}
           />
           <List.Item
             testID="menu-grapes"
-            title="Grapes"
+            title={t("nav.grapes")}
             left={(props) => (
               <List.Icon {...props} icon="fruit-grapes-outline" />
             )}
@@ -108,17 +117,17 @@ export default function MoreScreen() {
         <Divider />
 
         <List.Section>
-          <List.Subheader>Storage</List.Subheader>
+          <List.Subheader>{t("section.storage")}</List.Subheader>
           <List.Item
             testID="menu-storages"
-            title="Storages"
+            title={t("nav.storages")}
             left={(props) => <List.Icon {...props} icon="warehouse" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
             onPress={() => router.push("/storages")}
           />
           <List.Item
             testID="menu-locations"
-            title="Locations"
+            title={t("nav.locations")}
             left={(props) => (
               <List.Icon {...props} icon="map-marker-radius-outline" />
             )}
@@ -130,10 +139,10 @@ export default function MoreScreen() {
         <Divider />
 
         <List.Section>
-          <List.Subheader>Account</List.Subheader>
+          <List.Subheader>{t("section.account")}</List.Subheader>
           <List.Item
             testID="menu-profile"
-            title="Profile"
+            title={t("nav.profile")}
             description={user?.email}
             left={(props) => <List.Icon {...props} icon="account-outline" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
@@ -141,7 +150,7 @@ export default function MoreScreen() {
           />
           <List.Item
             testID="menu-sign-out"
-            title="Sign Out"
+            title={t("action.signOut")}
             titleStyle={{ color: theme.colors.error }}
             left={(props) => (
               <List.Icon {...props} icon="logout" color={theme.colors.error} />
@@ -153,15 +162,25 @@ export default function MoreScreen() {
         <Divider />
 
         <List.Section>
-          <List.Subheader>Appearance</List.Subheader>
+          <List.Subheader>{t("section.appearance")}</List.Subheader>
           <List.Item
             testID="menu-appearance"
-            title="Theme"
+            title={t("theme.title")}
             description={themeLabels[preference]}
             left={(props) => <List.Icon {...props} icon="theme-light-dark" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
             onPress={() => setThemeDialogVisible(true)}
           />
+          {isAdmin && (
+            <List.Item
+              testID="menu-language"
+              title={t("settings.language")}
+              description={getLanguageLabel(language)}
+              left={(props) => <List.Icon {...props} icon="translate" />}
+              right={(props) => <List.Icon {...props} icon="chevron-right" />}
+              onPress={() => setLanguageDialogVisible(true)}
+            />
+          )}
         </List.Section>
 
         <Portal>
@@ -169,7 +188,7 @@ export default function MoreScreen() {
             visible={themeDialogVisible}
             onDismiss={() => setThemeDialogVisible(false)}
           >
-            <Dialog.Title>Theme</Dialog.Title>
+            <Dialog.Title>{t("theme.title")}</Dialog.Title>
             <Dialog.Content>
               <RadioButton.Group
                 value={preference}
@@ -178,9 +197,32 @@ export default function MoreScreen() {
                   setThemeDialogVisible(false);
                 }}
               >
-                <RadioButton.Item label="Light" value="light" />
-                <RadioButton.Item label="Dark" value="dark" />
-                <RadioButton.Item label="System default" value="system" />
+                <RadioButton.Item label={t("theme.light")} value="light" />
+                <RadioButton.Item label={t("theme.dark")} value="dark" />
+                <RadioButton.Item label={t("theme.system")} value="system" />
+              </RadioButton.Group>
+            </Dialog.Content>
+          </Dialog>
+          <Dialog
+            visible={languageDialogVisible}
+            onDismiss={() => setLanguageDialogVisible(false)}
+          >
+            <Dialog.Title>{t("settings.language")}</Dialog.Title>
+            <Dialog.Content>
+              <RadioButton.Group
+                value={language}
+                onValueChange={(value) => {
+                  updateSetting.mutate({ key: "language", value });
+                  setLanguageDialogVisible(false);
+                }}
+              >
+                {SUPPORTED_LANGUAGE_OPTIONS.map((option) => (
+                  <RadioButton.Item
+                    key={option.value}
+                    label={option.label}
+                    value={option.value}
+                  />
+                ))}
               </RadioButton.Group>
             </Dialog.Content>
           </Dialog>
@@ -190,17 +232,17 @@ export default function MoreScreen() {
           <>
             <Divider />
             <List.Section>
-              <List.Subheader>CellarBoss Server</List.Subheader>
+              <List.Subheader>{t("section.server")}</List.Subheader>
 
               <List.Item
                 testID="menu-server"
-                title="URL"
+                title={t("server.url")}
                 description={apiBaseUrl}
                 left={(props) => <List.Icon {...props} icon="server-network" />}
               />
               <List.Item
                 testID="menu-server-version"
-                title="Version"
+                title={t("server.version")}
                 description={versionQuery.data?.version}
                 left={(props) => <List.Icon {...props} icon="tag-outline" />}
               />
@@ -210,11 +252,13 @@ export default function MoreScreen() {
 
         <Divider />
         <List.Section>
-          <List.Subheader>CellarBoss Mobile</List.Subheader>
+          <List.Subheader>{t("section.mobile")}</List.Subheader>
           <List.Item
             testID="menu-app-version"
-            title="Application Version"
-            description={Application.nativeApplicationVersion ?? "Unknown"}
+            title={t("mobile.applicationVersion")}
+            description={
+              Application.nativeApplicationVersion ?? t("status.unknown")
+            }
             left={(props) => <List.Icon {...props} icon="wrench-outline" />}
           />
         </List.Section>

--- a/apps/mobile/src/app/(app)/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/_layout.tsx
@@ -7,6 +7,7 @@ import {
 import { Tabs } from "expo-router";
 import { Icon } from "react-native-paper";
 import { useAppTheme } from "@/hooks/use-app-theme";
+import { useI18n } from "@/contexts/i18n-context";
 
 // Tab folders are groups like `(cellar)`, `(wines)`, so detail routes can be
 // shared across every tab via the `(dashboard,cellar,wines,storages,more)/`
@@ -43,6 +44,7 @@ function resetTabOnPress({
 
 export default function TabLayout() {
   const theme = useAppTheme();
+  const { t } = useI18n();
 
   return (
     <Tabs
@@ -61,7 +63,7 @@ export default function TabLayout() {
         name="(dashboard)"
         listeners={resetTabOnPress}
         options={{
-          title: "Dashboard",
+          title: t("nav.dashboard"),
           tabBarButtonTestID: "dashboard-tab",
           tabBarIcon: ({ color, size }) => (
             <Icon source="view-dashboard-outline" size={size} color={color} />
@@ -72,7 +74,7 @@ export default function TabLayout() {
         name="(cellar)"
         listeners={resetTabOnPress}
         options={{
-          title: "Cellar",
+          title: t("nav.cellar"),
           tabBarButtonTestID: "cellar-tab",
           tabBarIcon: ({ color, size }) => (
             <Icon source="bottle-wine-outline" size={size} color={color} />
@@ -83,7 +85,7 @@ export default function TabLayout() {
         name="(wines)"
         listeners={resetTabOnPress}
         options={{
-          title: "Wines",
+          title: t("nav.wines"),
           tabBarButtonTestID: "wines-tab",
           tabBarIcon: ({ color, size }) => (
             <Icon source="glass-wine" size={size} color={color} />
@@ -94,7 +96,7 @@ export default function TabLayout() {
         name="(storages)"
         listeners={resetTabOnPress}
         options={{
-          title: "Storages",
+          title: t("nav.storages"),
           tabBarButtonTestID: "storages-tab",
           tabBarIcon: ({ color, size }) => (
             <Icon source="warehouse" size={size} color={color} />
@@ -105,7 +107,7 @@ export default function TabLayout() {
         name="(more)"
         listeners={resetTabOnPress}
         options={{
-          title: "More",
+          title: t("nav.more"),
           tabBarButtonTestID: "more-tab",
           tabBarIcon: ({ color, size }) => (
             <Icon source="dots-horizontal" size={size} color={color} />

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -15,9 +15,9 @@ import {
   ThemePreferenceProvider,
   useThemePreference,
 } from "@/contexts/theme-context";
+import { I18nProvider } from "@/contexts/i18n-context";
 import { useAppTheme } from "@/hooks/use-app-theme";
 
-// TODO: Support multiple languages and read the user's preferred language from the server settings
 registerTranslation("en", en);
 
 const queryClient = new QueryClient();
@@ -47,13 +47,15 @@ function AppProviders() {
     <PaperProvider theme={theme}>
       <NavigationThemeProvider value={navigationTheme}>
         <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <StatusBar
-              barStyle={isDark ? "light-content" : "dark-content"}
-              translucent={true}
-            />
-            <AuthGate />
-          </AuthProvider>
+          <I18nProvider>
+            <AuthProvider>
+              <StatusBar
+                barStyle={isDark ? "light-content" : "dark-content"}
+                translucent={true}
+              />
+              <AuthGate />
+            </AuthProvider>
+          </I18nProvider>
         </QueryClientProvider>
       </NavigationThemeProvider>
     </PaperProvider>

--- a/apps/mobile/src/contexts/i18n-context.tsx
+++ b/apps/mobile/src/contexts/i18n-context.tsx
@@ -1,0 +1,40 @@
+import { createContext, useCallback, useContext, type ReactNode } from "react";
+import {
+  DEFAULT_LANGUAGE,
+  resolveLanguage,
+  translate,
+  type SupportedLanguage,
+  type TranslationKey,
+} from "@cellarboss/common/i18n";
+import { useSetting } from "@/hooks/use-settings";
+
+type I18nContextValue = {
+  language: SupportedLanguage;
+  t: (key: TranslationKey) => string;
+};
+
+const fallbackContext: I18nContextValue = {
+  language: DEFAULT_LANGUAGE,
+  t: (key) => translate(DEFAULT_LANGUAGE, key),
+};
+
+const I18nContext = createContext<I18nContextValue>(fallbackContext);
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const languageSetting = useSetting("language");
+  const language = resolveLanguage(languageSetting.data);
+  const t = useCallback(
+    (key: TranslationKey) => translate(language, key),
+    [language],
+  );
+
+  return (
+    <I18nContext.Provider value={{ language, t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+}
+
+export function useI18n(): I18nContextValue {
+  return useContext(I18nContext);
+}

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -6,6 +6,7 @@ import { ReactNode, useState } from "react";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { SettingsProvider } from "@/contexts/settings-context";
+import { I18nProvider } from "@/contexts/i18n-context";
 
 export default function Providers({
   children,
@@ -21,9 +22,11 @@ export default function Providers({
       <NuqsAdapter>
         <QueryClientProvider client={queryClient}>
           <SettingsProvider>
-            <SidebarProvider defaultOpen={sidebarDefaultOpen}>
-              {children}
-            </SidebarProvider>
+            <I18nProvider>
+              <SidebarProvider defaultOpen={sidebarDefaultOpen}>
+                {children}
+              </SidebarProvider>
+            </I18nProvider>
           </SettingsProvider>
         </QueryClientProvider>
       </NuqsAdapter>

--- a/apps/web/app/settings/[key]/edit/page.tsx
+++ b/apps/web/app/settings/[key]/edit/page.tsx
@@ -3,13 +3,14 @@
 import { useParams } from "next/navigation";
 import { useSettings, useUpdateSetting } from "@/hooks/use-settings";
 import { GenericCard } from "@/components/cards/GenericCard";
-import { settingFields, type SettingFormData } from "@/lib/fields/settings";
+import { getSettingFields, type SettingFormData } from "@/lib/fields/settings";
 import { ApiResult } from "@/lib/api/types";
 import { PageHeader } from "@/components/page/PageHeader";
 import { LoadingCard } from "@/components/cards/LoadingCard";
 import { ErrorCard } from "@/components/cards/ErrorCard";
 import { useQueryClient } from "@tanstack/react-query";
 import { type ParsedSettingsMap } from "@/lib/constants/settings";
+import { useI18n } from "@/contexts/i18n-context";
 
 export default function EditSettingPage() {
   const params = useParams();
@@ -18,6 +19,7 @@ export default function EditSettingPage() {
   const settingsQuery = useSettings();
   const updateMutation = useUpdateSetting();
   const queryClient = useQueryClient();
+  const { t } = useI18n();
 
   if (settingsQuery.isLoading) {
     return <LoadingCard />;
@@ -68,11 +70,11 @@ export default function EditSettingPage() {
 
   return (
     <section>
-      <PageHeader title="Edit Setting" />
+      <PageHeader title={t("settings.editSetting")} />
       <GenericCard<SettingFormData>
         mode="edit"
         data={settingData}
-        fields={settingFields}
+        fields={getSettingFields(key)}
         processSave={handleUpdate}
         redirectTo="/settings"
       />

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -7,12 +7,18 @@ import { authClient } from "@/lib/auth-client";
 import { LoadingCard } from "@/components/cards/LoadingCard";
 import { ErrorCard } from "@/components/cards/ErrorCard";
 import { EditButton } from "@/components/buttons/EditButton";
-import { type ParsedSettingsMap } from "@/lib/constants/settings";
+import {
+  type ParsedSettingsMap,
+  type SettingValueType,
+} from "@/lib/constants/settings";
+import { useI18n } from "@/contexts/i18n-context";
+import { getLanguageLabel } from "@cellarboss/common/i18n";
 
 export default function SettingsAdminPage() {
   const router = useRouter();
   const session = authClient.useSession();
   const settingsQuery = useSettings();
+  const { t } = useI18n();
 
   const isAdmin = session.data?.user?.role === "admin";
 
@@ -31,10 +37,9 @@ export default function SettingsAdminPage() {
   if (!isAdmin) {
     return (
       <section>
-        <PageHeader title="System Settings" />
+        <PageHeader title={t("settings.systemSettings")} />
         <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-800">
-          You do not have permission to access this page. Admin rights are
-          required.
+          {t("settings.noPermission")}
         </div>
       </section>
     );
@@ -44,11 +49,11 @@ export default function SettingsAdminPage() {
 
   return (
     <section>
-      <PageHeader title="System Settings" />
+      <PageHeader title={t("settings.systemSettings")} />
 
       {settings.size === 0 ? (
         <div className="bg-card border border-border rounded-lg p-6 text-center text-muted-foreground">
-          No settings configured yet.
+          {t("settings.noSettings")}
         </div>
       ) : (
         <div className="space-y-3">
@@ -65,7 +70,7 @@ export default function SettingsAdminPage() {
                       null
                     </span>
                   ) : (
-                    String(value)
+                    formatSettingValue(key, value)
                   )}
                 </div>
               </div>
@@ -80,4 +85,11 @@ export default function SettingsAdminPage() {
       )}
     </section>
   );
+}
+
+function formatSettingValue(key: string, value: SettingValueType) {
+  if (key === "language") {
+    return getLanguageLabel(value);
+  }
+  return String(value);
 }

--- a/apps/web/components/sidebar/AppSidebar.tsx
+++ b/apps/web/components/sidebar/AppSidebar.tsx
@@ -20,6 +20,7 @@ import {
   ChevronsUpDown,
   Moon,
   Sun,
+  type LucideIcon,
 } from "lucide-react";
 import { useTheme } from "next-themes";
 import { authClient } from "@/lib/auth-client";
@@ -52,31 +53,49 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "@/components/ui/tooltip";
+import { useI18n } from "@/contexts/i18n-context";
+import type { TranslationKey } from "@cellarboss/common/i18n";
+
+type SidebarItem = {
+  titleKey: TranslationKey;
+  url: string;
+  icon: LucideIcon;
+};
 
 const wineItems = [
-  { title: "Bottles", url: "/bottles", icon: BottleWine },
-  { title: "Wines", url: "/wines", icon: Barrel },
-  { title: "Tasting Notes", url: "/tasting-notes", icon: ClipboardList },
-  { title: "Grapes", url: "/grapes", icon: Grape },
-  { title: "Winemakers", url: "/winemakers", icon: User },
-];
+  { titleKey: "nav.bottles", url: "/bottles", icon: BottleWine },
+  { titleKey: "nav.wines", url: "/wines", icon: Barrel },
+  {
+    titleKey: "nav.tastingNotes",
+    url: "/tasting-notes",
+    icon: ClipboardList,
+  },
+  { titleKey: "nav.grapes", url: "/grapes", icon: Grape },
+  { titleKey: "nav.winemakers", url: "/winemakers", icon: User },
+] satisfies SidebarItem[];
 
 const storageItems = [
-  { title: "Storages", url: "/storages", icon: Refrigerator },
-  { title: "Locations", url: "/locations", icon: MapPin },
-];
+  { titleKey: "nav.storages", url: "/storages", icon: Refrigerator },
+  { titleKey: "nav.locations", url: "/locations", icon: MapPin },
+] satisfies SidebarItem[];
 
 const geographyItems = [
-  { title: "Regions", url: "/regions", icon: Flag },
-  { title: "Countries", url: "/countries", icon: Earth },
-];
+  { titleKey: "nav.regions", url: "/regions", icon: Flag },
+  { titleKey: "nav.countries", url: "/countries", icon: Earth },
+] satisfies SidebarItem[];
 
 const settingsItems = [
-  { title: "Profile", url: "/profile", icon: UserCircle },
-  { title: "Application Settings", url: "/settings", icon: Settings },
-];
+  { titleKey: "nav.profile", url: "/profile", icon: UserCircle },
+  {
+    titleKey: "nav.applicationSettings",
+    url: "/settings",
+    icon: Settings,
+  },
+] satisfies SidebarItem[];
 
-const adminItems = [{ title: "Users", url: "/users", icon: Users }];
+const adminItems = [
+  { titleKey: "nav.users", url: "/users", icon: Users },
+] satisfies SidebarItem[];
 
 function getInitials(name: string) {
   return name
@@ -90,6 +109,7 @@ function getInitials(name: string) {
 export function AppSidebar() {
   const { toggleSidebar, state, isMobile } = useSidebar();
   const { theme, setTheme } = useTheme();
+  const { t } = useI18n();
   const session = authClient.useSession();
   const user = session.data?.user;
   const isAdmin = user?.role === "admin";
@@ -100,14 +120,14 @@ export function AppSidebar() {
   };
 
   const sections = [
-    { label: "Wines", items: wineItems },
-    { label: "Storage", items: storageItems },
-    { label: "Geography", items: geographyItems },
+    { labelKey: "section.wineData", items: wineItems },
+    { labelKey: "section.storage", items: storageItems },
+    { labelKey: "section.geography", items: geographyItems },
     {
-      label: "Settings",
+      labelKey: "nav.settings",
       items: isAdmin ? [...settingsItems, ...adminItems] : settingsItems,
     },
-  ];
+  ] satisfies { labelKey: TranslationKey; items: SidebarItem[] }[];
 
   return (
     <Sidebar collapsible="icon">
@@ -120,27 +140,27 @@ export function AppSidebar() {
             >
               <BottleWine className="h-5 w-5 shrink-0" />
               <span className="group-data-[collapsible=icon]:hidden">
-                CellarBoss
+                {t("app.name")}
               </span>
             </Link>
           </TooltipTrigger>
           <TooltipContent side="right" hidden={state !== "collapsed"}>
-            Dashboard
+            {t("nav.dashboard")}
           </TooltipContent>
         </Tooltip>
       </SidebarHeader>
       <SidebarContent>
-        {sections.map(({ label, items }) => (
-          <SidebarGroup key={label}>
-            <SidebarGroupLabel>{label}</SidebarGroupLabel>
+        {sections.map(({ labelKey, items }) => (
+          <SidebarGroup key={labelKey}>
+            <SidebarGroupLabel>{t(labelKey)}</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 {items.map((item) => (
-                  <SidebarMenuItem key={item.title}>
-                    <SidebarMenuButton asChild tooltip={item.title}>
+                  <SidebarMenuItem key={item.titleKey}>
+                    <SidebarMenuButton asChild tooltip={t(item.titleKey)}>
                       <a href={item.url}>
                         <item.icon />
-                        <span>{item.title}</span>
+                        <span>{t(item.titleKey)}</span>
                       </a>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
@@ -203,18 +223,18 @@ export function AppSidebar() {
                     ) : (
                       <Moon className="size-4" />
                     )}
-                    Toggle theme
+                    {t("action.toggleTheme")}
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => toggleSidebar()}>
                     {state === "expanded" ? (
                       <>
                         <PanelLeftClose className="size-4" />
-                        Collapse sidebar
+                        {t("action.collapseSidebar")}
                       </>
                     ) : (
                       <>
                         <PanelLeftOpen className="size-4" />
-                        Expand sidebar
+                        {t("action.expandSidebar")}
                       </>
                     )}
                   </DropdownMenuItem>
@@ -224,14 +244,14 @@ export function AppSidebar() {
                   <DropdownMenuItem asChild>
                     <a href="/profile">
                       <UserCircle className="size-4" />
-                      Profile
+                      {t("nav.profile")}
                     </a>
                   </DropdownMenuItem>
                   {isAdmin && (
                     <DropdownMenuItem asChild>
                       <a href="/settings">
                         <Settings className="size-4" />
-                        Settings
+                        {t("nav.settings")}
                       </a>
                     </DropdownMenuItem>
                   )}
@@ -239,7 +259,7 @@ export function AppSidebar() {
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={handleLogout}>
                   <LogOut className="size-4" />
-                  Log out
+                  {t("action.logOut")}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>

--- a/apps/web/contexts/i18n-context.tsx
+++ b/apps/web/contexts/i18n-context.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { createContext, useCallback, useContext, type ReactNode } from "react";
+import {
+  DEFAULT_LANGUAGE,
+  resolveLanguage,
+  translate,
+  type SupportedLanguage,
+  type TranslationKey,
+} from "@cellarboss/common/i18n";
+import { useSettingsContext } from "@/contexts/settings-context";
+
+type I18nContextValue = {
+  language: SupportedLanguage;
+  t: (key: TranslationKey) => string;
+};
+
+const fallbackContext: I18nContextValue = {
+  language: DEFAULT_LANGUAGE,
+  t: (key) => translate(DEFAULT_LANGUAGE, key),
+};
+
+const I18nContext = createContext<I18nContextValue>(fallbackContext);
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const settings = useSettingsContext();
+  const language = resolveLanguage(settings.get("language"));
+  const t = useCallback(
+    (key: TranslationKey) => translate(language, key),
+    [language],
+  );
+
+  return (
+    <I18nContext.Provider value={{ language, t }}>
+      {children}
+    </I18nContext.Provider>
+  );
+}
+
+export function useI18n(): I18nContextValue {
+  return useContext(I18nContext);
+}

--- a/apps/web/lib/fields/__tests__/settings.test.ts
+++ b/apps/web/lib/fields/__tests__/settings.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getSettingFields } from "../settings";
+
+describe("getSettingFields", () => {
+  it("uses language options for the language setting", () => {
+    const fields = getSettingFields("language");
+    const valueField = fields.find((field) => field.key === "value");
+
+    expect(valueField).toMatchObject({
+      type: "fixed-list",
+      label: "Language",
+    });
+    expect("options" in valueField! ? valueField.options : []).toEqual([
+      { value: "en", label: "English" },
+      { value: "es", label: "Español" },
+      { value: "fr", label: "Français" },
+    ]);
+  });
+
+  it("keeps free-text editing for other settings", () => {
+    const fields = getSettingFields("currency");
+    const valueField = fields.find((field) => field.key === "value");
+
+    expect(valueField).toMatchObject({
+      type: "text",
+      label: "Value",
+    });
+  });
+});

--- a/apps/web/lib/fields/settings.ts
+++ b/apps/web/lib/fields/settings.ts
@@ -1,4 +1,5 @@
 import type { FieldConfig } from "@/lib/types/field";
+import { SUPPORTED_LANGUAGE_OPTIONS } from "@cellarboss/common/i18n";
 import * as z from "zod";
 
 export type SettingFormData = {
@@ -7,14 +8,16 @@ export type SettingFormData = {
   value: string;
 };
 
+const settingKeyField: FieldConfig<SettingFormData> = {
+  key: "key",
+  label: "Setting Key",
+  type: "text",
+  validator: z.string().min(1, "Key is required").max(255),
+  editable: false,
+};
+
 export const settingFields: FieldConfig<SettingFormData>[] = [
-  {
-    key: "key",
-    label: "Setting Key",
-    type: "text",
-    validator: z.string().min(1, "Key is required").max(255),
-    editable: false,
-  },
+  settingKeyField,
   {
     key: "value",
     label: "Value",
@@ -22,3 +25,23 @@ export const settingFields: FieldConfig<SettingFormData>[] = [
     validator: z.string().min(0).max(10000),
   },
 ];
+
+export function getSettingFields(key: string): FieldConfig<SettingFormData>[] {
+  if (key === "language") {
+    return [
+      settingKeyField,
+      {
+        key: "value",
+        label: "Language",
+        type: "fixed-list",
+        options: SUPPORTED_LANGUAGE_OPTIONS.map((option) => ({
+          value: option.value,
+          label: option.label,
+        })),
+        validator: z.enum(["en", "es", "fr"]),
+      },
+    ];
+  }
+
+  return settingFields;
+}

--- a/packages/common/src/__tests__/i18n.test.ts
+++ b/packages/common/src/__tests__/i18n.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LANGUAGE,
+  getLanguageLabel,
+  resolveLanguage,
+  translate,
+} from "../i18n";
+
+describe("resolveLanguage", () => {
+  it("returns exact supported languages", () => {
+    expect(resolveLanguage("es")).toBe("es");
+    expect(resolveLanguage("fr")).toBe("fr");
+  });
+
+  it("normalizes regional language tags", () => {
+    expect(resolveLanguage("es-MX")).toBe("es");
+    expect(resolveLanguage("fr-CA")).toBe("fr");
+  });
+
+  it("falls back to the default language for unsupported values", () => {
+    expect(resolveLanguage("de")).toBe(DEFAULT_LANGUAGE);
+    expect(resolveLanguage(null)).toBe(DEFAULT_LANGUAGE);
+  });
+});
+
+describe("translate", () => {
+  it("returns translated labels", () => {
+    expect(translate("es", "nav.wines")).toBe("Vinos");
+    expect(translate("fr", "settings.language")).toBe("Langue");
+  });
+});
+
+describe("getLanguageLabel", () => {
+  it("returns display labels for supported languages", () => {
+    expect(getLanguageLabel("en")).toBe("English");
+    expect(getLanguageLabel("es")).toBe("Español");
+  });
+});

--- a/packages/common/src/i18n.ts
+++ b/packages/common/src/i18n.ts
@@ -1,0 +1,191 @@
+const en = {
+  "app.name": "CellarBoss",
+  "nav.dashboard": "Dashboard",
+  "nav.cellar": "Cellar",
+  "nav.wines": "Wines",
+  "nav.bottles": "Bottles",
+  "nav.tastingNotes": "Tasting Notes",
+  "nav.grapes": "Grapes",
+  "nav.winemakers": "Winemakers",
+  "nav.storages": "Storages",
+  "nav.locations": "Locations",
+  "nav.regions": "Regions",
+  "nav.countries": "Countries",
+  "nav.profile": "Profile",
+  "nav.settings": "Settings",
+  "nav.applicationSettings": "Application Settings",
+  "nav.users": "Users",
+  "nav.more": "More",
+  "section.wineData": "Wine Data",
+  "section.referenceData": "Reference Data",
+  "section.storage": "Storage",
+  "section.geography": "Geography",
+  "section.account": "Account",
+  "section.appearance": "Appearance",
+  "section.server": "CellarBoss Server",
+  "section.mobile": "CellarBoss Mobile",
+  "action.toggleTheme": "Toggle theme",
+  "action.collapseSidebar": "Collapse sidebar",
+  "action.expandSidebar": "Expand sidebar",
+  "action.signOut": "Sign Out",
+  "action.logOut": "Log out",
+  "theme.title": "Theme",
+  "theme.light": "Light",
+  "theme.dark": "Dark",
+  "theme.system": "System default",
+  "settings.language": "Language",
+  "settings.editSetting": "Edit Setting",
+  "settings.systemSettings": "System Settings",
+  "settings.noSettings": "No settings configured yet.",
+  "settings.noPermission":
+    "You do not have permission to access this page. Admin rights are required.",
+  "status.unknown": "Unknown",
+  "server.url": "URL",
+  "server.version": "Version",
+  "mobile.applicationVersion": "Application Version",
+} as const;
+
+export type TranslationKey = keyof typeof en;
+type TranslationMap = Record<TranslationKey, string>;
+
+const es: TranslationMap = {
+  "app.name": "CellarBoss",
+  "nav.dashboard": "Panel",
+  "nav.cellar": "Bodega",
+  "nav.wines": "Vinos",
+  "nav.bottles": "Botellas",
+  "nav.tastingNotes": "Notas de cata",
+  "nav.grapes": "Uvas",
+  "nav.winemakers": "Productores",
+  "nav.storages": "Almacenes",
+  "nav.locations": "Ubicaciones",
+  "nav.regions": "Regiones",
+  "nav.countries": "Países",
+  "nav.profile": "Perfil",
+  "nav.settings": "Configuración",
+  "nav.applicationSettings": "Configuración de la aplicación",
+  "nav.users": "Usuarios",
+  "nav.more": "Más",
+  "section.wineData": "Datos de vino",
+  "section.referenceData": "Datos de referencia",
+  "section.storage": "Almacenamiento",
+  "section.geography": "Geografía",
+  "section.account": "Cuenta",
+  "section.appearance": "Apariencia",
+  "section.server": "Servidor CellarBoss",
+  "section.mobile": "CellarBoss móvil",
+  "action.toggleTheme": "Cambiar tema",
+  "action.collapseSidebar": "Contraer barra lateral",
+  "action.expandSidebar": "Expandir barra lateral",
+  "action.signOut": "Cerrar sesión",
+  "action.logOut": "Cerrar sesión",
+  "theme.title": "Tema",
+  "theme.light": "Claro",
+  "theme.dark": "Oscuro",
+  "theme.system": "Predeterminado del sistema",
+  "settings.language": "Idioma",
+  "settings.editSetting": "Editar configuración",
+  "settings.systemSettings": "Configuración del sistema",
+  "settings.noSettings": "No hay configuración disponible.",
+  "settings.noPermission":
+    "No tienes permiso para acceder a esta página. Se requieren permisos de administrador.",
+  "status.unknown": "Desconocido",
+  "server.url": "URL",
+  "server.version": "Versión",
+  "mobile.applicationVersion": "Versión de la aplicación",
+};
+
+const fr: TranslationMap = {
+  "app.name": "CellarBoss",
+  "nav.dashboard": "Tableau de bord",
+  "nav.cellar": "Cave",
+  "nav.wines": "Vins",
+  "nav.bottles": "Bouteilles",
+  "nav.tastingNotes": "Notes de dégustation",
+  "nav.grapes": "Cépages",
+  "nav.winemakers": "Producteurs",
+  "nav.storages": "Stockages",
+  "nav.locations": "Emplacements",
+  "nav.regions": "Régions",
+  "nav.countries": "Pays",
+  "nav.profile": "Profil",
+  "nav.settings": "Paramètres",
+  "nav.applicationSettings": "Paramètres de l'application",
+  "nav.users": "Utilisateurs",
+  "nav.more": "Plus",
+  "section.wineData": "Données des vins",
+  "section.referenceData": "Données de référence",
+  "section.storage": "Stockage",
+  "section.geography": "Géographie",
+  "section.account": "Compte",
+  "section.appearance": "Apparence",
+  "section.server": "Serveur CellarBoss",
+  "section.mobile": "CellarBoss mobile",
+  "action.toggleTheme": "Changer de thème",
+  "action.collapseSidebar": "Réduire la barre latérale",
+  "action.expandSidebar": "Développer la barre latérale",
+  "action.signOut": "Se déconnecter",
+  "action.logOut": "Se déconnecter",
+  "theme.title": "Thème",
+  "theme.light": "Clair",
+  "theme.dark": "Sombre",
+  "theme.system": "Valeur par défaut du système",
+  "settings.language": "Langue",
+  "settings.editSetting": "Modifier le paramètre",
+  "settings.systemSettings": "Paramètres du système",
+  "settings.noSettings": "Aucun paramètre configuré.",
+  "settings.noPermission":
+    "Vous n'avez pas l'autorisation d'accéder à cette page. Les droits administrateur sont requis.",
+  "status.unknown": "Inconnu",
+  "server.url": "URL",
+  "server.version": "Version",
+  "mobile.applicationVersion": "Version de l'application",
+};
+
+export const DEFAULT_LANGUAGE = "en";
+
+export const SUPPORTED_LANGUAGE_OPTIONS = [
+  { value: "en", label: "English" },
+  { value: "es", label: "Español" },
+  { value: "fr", label: "Français" },
+] as const;
+
+export type SupportedLanguage =
+  (typeof SUPPORTED_LANGUAGE_OPTIONS)[number]["value"];
+
+export const translations: Record<SupportedLanguage, TranslationMap> = {
+  en,
+  es,
+  fr,
+};
+
+export function resolveLanguage(value: unknown): SupportedLanguage {
+  if (typeof value !== "string") return DEFAULT_LANGUAGE;
+
+  const normalized = value.trim().toLowerCase();
+  const exact = SUPPORTED_LANGUAGE_OPTIONS.find(
+    (option) => option.value === normalized,
+  );
+  if (exact) return exact.value;
+
+  const baseLanguage = normalized.split("-")[0];
+  const base = SUPPORTED_LANGUAGE_OPTIONS.find(
+    (option) => option.value === baseLanguage,
+  );
+  return base?.value ?? DEFAULT_LANGUAGE;
+}
+
+export function translate(
+  language: SupportedLanguage,
+  key: TranslationKey,
+): string {
+  return translations[language][key] ?? translations[DEFAULT_LANGUAGE][key];
+}
+
+export function getLanguageLabel(value: unknown): string {
+  const language = resolveLanguage(value);
+  return (
+    SUPPORTED_LANGUAGE_OPTIONS.find((option) => option.value === language)
+      ?.label ?? "English"
+  );
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -30,6 +30,18 @@ export {
   parseValue,
 } from "./settings";
 
+// Internationalisation
+export {
+  DEFAULT_LANGUAGE,
+  SUPPORTED_LANGUAGE_OPTIONS,
+  translations,
+  resolveLanguage,
+  translate,
+  getLanguageLabel,
+  type SupportedLanguage,
+  type TranslationKey,
+} from "./i18n";
+
 // Hooks
 export { useApiQuery, type UseApiQueryResult } from "./hooks/use-api-query";
 export { createSettingsHooks } from "./hooks/use-settings";


### PR DESCRIPTION
## Summary
- add a shared `@cellarboss/common` translation catalog with English, Spanish, and French labels
- resolve frontend language from the existing `language` system setting, giving CellarBoss a per-installation language configuration path
- translate web app chrome/settings UI and add a fixed language selector for the `language` setting
- translate mobile tab labels and the More screen, including an admin-only language selector backed by the settings API

Closes #278

## Notes
- This keeps per-user language overrides out of scope until user preferences land, but the shared provider/catalog can consume that later without changing translation keys.

## Validation
- `pnpm --filter @cellarboss/common test -- src/__tests__/i18n.test.ts`
- `pnpm --filter @cellarboss/web test -- lib/fields/__tests__/settings.test.ts`
- `pnpm --filter @cellarboss/web build`
- `pnpm --filter @cellarboss/web lint`
- `pnpm --filter @cellarboss/mobile exec tsc --noEmit`
- `pnpm --filter @cellarboss/mobile test -- src/__tests__/screens/more.test.tsx --runInBand`
- `pnpm --filter @cellarboss/mobile test --runInBand`
- `pnpm exec prettier --check packages/common/src/i18n.ts packages/common/src/__tests__/i18n.test.ts packages/common/src/index.ts apps/web/contexts/i18n-context.tsx apps/web/app/providers.tsx apps/web/lib/fields/settings.ts apps/web/lib/fields/__tests__/settings.test.ts apps/web/app/settings/[key]/edit/page.tsx apps/web/app/settings/page.tsx apps/web/components/sidebar/AppSidebar.tsx apps/mobile/src/contexts/i18n-context.tsx apps/mobile/src/app/_layout.tsx apps/mobile/src/app/(app)/(tabs)/_layout.tsx apps/mobile/src/app/(app)/(tabs)/(more)/more.tsx`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multilingual support enabling users to choose between English, Spanish, and French
  * Language preference is now configurable through application settings
  * All navigation items, menus, dialogs, and interface labels are localised based on the selected language

<!-- end of auto-generated comment: release notes by coderabbit.ai -->