### PR TITLE
chore: Remove hardcoded pnpm version from Dockerfile

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS builder
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
-
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+RUN corepack enable && corepack prepare --activate
 COPY apps/backend ./apps/backend
 COPY packages ./packages
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,9 +1,9 @@
 FROM node:24.16.0-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14 AS builder
 WORKDIR /app
 
-RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
-
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+RUN corepack enable && corepack prepare --activate
 COPY apps/web ./apps/web
 COPY packages ./packages
 


### PR DESCRIPTION
## Summary

Removes hardcoded versions of `pnpm` from both backend & web `Dockerfile`

## Changes

- Reorder Dockerfile to ensure that `package.json` etc is present before we run `corepack`
- Remove hardcoded `pnpm` version that had fallen well behind! Desired version will now be automatically pulled from `package.json`

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Dependency update
- [ ] Docs / config only

## Areas affected

- [x] Backend
- [x] Web application
- [ ] Android application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to streamline package manager setup across backend and web services. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->