### PR TITLE
fix: Preferences endpoint not mounting correctly

### DIFF
--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -29,8 +29,12 @@ export function registerRoutes(app: OpenAPIHono) {
   registerWineMakerRoutes(app);
   registerSettingsRoutes(app);
   registerTastingNoteRoutes(app);
+  // Preferences mount at /user/preferences, which overlaps the /user/{id} route
+  // registered by the user routes. Hono resolves overlapping mounts by
+  // registration order, so preferences must be registered first to avoid being
+  // shadowed by /user/{id}.
+  registerPreferenceRoutes(app);
   registerUserRoutes(app);
   registerVersionRoutes(app);
   registerImageRoutes(app);
-  registerPreferenceRoutes(app);
 }

--- a/apps/backend/src/tests/preferences.test.ts
+++ b/apps/backend/src/tests/preferences.test.ts
@@ -8,6 +8,7 @@ import {
   createTestUser,
 } from "./setup";
 import { registerPreferenceRoutes } from "@routes/preferences.routes.js";
+import { registerRoutes } from "@routes/index.js";
 import { db } from "@utils/database.js";
 
 const USER_ID = "test-user-1";
@@ -192,6 +193,41 @@ describe("Preferences API", () => {
       const res = await otherApp.request("/user/preferences");
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual([]);
+    });
+  });
+
+  // Regression: the `/user/{id}` route (registered for users) must not shadow
+  // `/user/preferences`. Uses the real registerRoutes so it guards the
+  // production registration order, not a hand-rolled one.
+  describe("route precedence alongside user routes", () => {
+    let app: OpenAPIHono;
+
+    beforeEach(() => {
+      app = createTestAppWithAuth(USER_ID);
+      registerRoutes(app);
+    });
+
+    it("GET /user/preferences is not shadowed by GET /user/{id}", async () => {
+      const res = await app.request("/user/preferences");
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual([]);
+    });
+
+    it("round-trips a saved preference", async () => {
+      const value = JSON.stringify({ name: true, vintage: false });
+      const put = await app.request("/user/preferences/columns.bottles", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value }),
+      });
+      expect(put.status).toBe(200);
+
+      const res = await app.request("/user/preferences");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data).toHaveLength(1);
+      expect(data[0].key).toBe("columns.bottles");
+      expect(data[0].value).toBe(value);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fix order in which backend endpoints are mounted, to fix `/user/preferences/` not being accessible vs `/user/{id}`

## Changes

- Change order of endpoint mounting
- Add regression test

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [ ] Docs / config only

## Areas affected

- [x] Backend
- [ ] Web application
- [ ] Android application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected the order of API endpoint registration to ensure the user preferences endpoint is consistently accessible and not overshadowed by other user endpoints.

## Tests
* Introduced regression tests to verify the preferences endpoint functions correctly and remains accessible when combined with other user account management endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->