### PR TITLE
chore: Security hardening of workflows

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: inputs.detect-changes
+        with:
+          persist-credentials: false
 
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
@@ -56,6 +58,8 @@ jobs:
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Build frontend
@@ -84,6 +88,8 @@ jobs:
     if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Run validators unit tests
@@ -104,6 +110,8 @@ jobs:
     if: needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Run common unit tests
@@ -168,6 +176,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Build backend
@@ -197,6 +207,8 @@ jobs:
     if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Run mobile unit tests
@@ -217,6 +229,8 @@ jobs:
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Cache Playwright browsers
@@ -276,6 +290,8 @@ jobs:
     if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.structure == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Expo doctor
@@ -293,6 +309,8 @@ jobs:
     if: needs.changes.outputs.backend == 'true' || needs.changes.outputs.packages == 'true' || needs.changes.outputs.structure == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Validate API docs generation
@@ -305,6 +323,8 @@ jobs:
     if: needs.changes.outputs.web == 'true' || needs.changes.outputs.packages == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Build docs (without screenshots)
@@ -317,6 +337,8 @@ jobs:
     if: needs.changes.outputs.mobile == 'true' || needs.changes.outputs.packages == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Build docs (without screenshots)

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -362,13 +362,15 @@ jobs:
 
     steps:
     - id: skips
+      env:
+        NEEDS_JSON: ${{ toJSON(needs) }}
       run: |
-        echo "allowed=$(echo '${{ toJSON(needs) }}' | jq -r '
+        echo "allowed=$(echo "$NEEDS_JSON" | jq -r '
         to_entries
         | map(select(.value.result == "skipped"))
         | map(.key)
         | join(",")
-         ')" >> $GITHUB_OUTPUT
+         ')" >> "$GITHUB_OUTPUT"
 
     - uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
       with:

--- a/.github/workflows/expo-update.yml
+++ b/.github/workflows/expo-update.yml
@@ -50,6 +50,7 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.cpr.outputs.pull-request-number
-        run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        run: gh pr merge --merge --auto "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ secrets.PR_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -6,15 +6,18 @@ on:
     types:
       - completed
 
-permissions:
-  actions: read
-  pull-requests: write
+# Default to no permissions; jobs that comment on PRs elevate their own.
+permissions: {}
 
 jobs:
   coverage:
     name: Post Coverage Comment
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      actions: read # download artifacts from the triggering workflow run
+      contents: read # checkout
+      pull-requests: write # post coverage comment
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -105,6 +108,9 @@ jobs:
     name: Post Playwright Report
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request'
+    permissions:
+      actions: read # download artifacts from the triggering workflow run
+      pull-requests: write # post Playwright report comment
     steps:
       - name: Download Playwright results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download web coverage
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,6 +7,7 @@ on:
     types:
       - opened
       - edited
+      - synchronize
       - reopened
       - ready_for_review
 

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,39 @@
+name: PR Title
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            chore
+            docs
+            deps
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: |
+            The PR title must have a description after the type prefix.
+            Example: "feat: add bottle search"
+          ignoreLabels: |
+            skip-changelog

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -6,43 +6,17 @@ on:
       - main
     types:
       - opened
-      - edited
       - synchronize
       - reopened
       - ready_for_review
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
-  check-title:
-    name: Validate PR Title
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          types: |
-            feat
-            fix
-            refactor
-            chore
-            docs
-            deps
-          requireScope: false
-          subjectPattern: ^.+$
-          subjectPatternError: |
-            The PR title must have a description after the type prefix.
-            Example: "feat: add bottle search"
-          ignoreLabels: |
-            skip-changelog
-
   prettier:
     name: Check Formatting
     runs-on: ubuntu-latest
-    if: github.event.action != 'edited'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -55,7 +29,6 @@ jobs:
   zizmor:
     name: Workflow Security Scan
     runs-on: ubuntu-latest
-    if: github.event.action != 'edited'
     permissions:
       contents: read
       security-events: write # upload SARIF to code scanning when available

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -45,6 +45,8 @@ jobs:
     if: github.event.action != 'edited'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Check formatting

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -51,3 +51,22 @@ jobs:
 
       - name: Check formatting
         run: pnpm prettier --check "**/*.{ts,tsx,md}"
+
+  zizmor:
+    name: Workflow Security Scan
+    runs-on: ubuntu-latest
+    if: github.event.action != 'edited'
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code scanning when available
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          # Auto-detect whether code scanning (SARIF upload) is available;
+          # otherwise the action just fails the build on findings.
+          advanced-security: auto

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -335,10 +335,13 @@ jobs:
           path: artifacts/
 
       - name: Generate What's New text
+        env:
+          RELEASE_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: |
           mkdir -p whatsnew
-          echo "See what's new in this release: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}" > whatsnew/whatsnew-en-US
-          echo "See what's new in this release: https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}" > whatsnew/whatsnew-en-GB
+          echo "See what's new in this release: https://github.com/${RELEASE_REPO}/releases/tag/${RELEASE_TAG}" > whatsnew/whatsnew-en-US
+          echo "See what's new in this release: https://github.com/${RELEASE_REPO}/releases/tag/${RELEASE_TAG}" > whatsnew/whatsnew-en-GB
 
       - name: Upload to Google Play (Internal Testing)
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
@@ -369,7 +372,9 @@ jobs:
           path: artifacts/
 
       - name: Rename AAB with version
-        run: mv artifacts/app-release.aab artifacts/cellarboss-${{ github.ref_name }}-android.aab
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: mv artifacts/app-release.aab "artifacts/cellarboss-${RELEASE_TAG}-android.aab"
 
       - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0
         id: release
@@ -381,9 +386,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload AAB to release
-        run: gh release upload ${{ github.ref_name }} artifacts/cellarboss-${{ github.ref_name }}-android.aab --clobber
+        run: gh release upload "$RELEASE_TAG" "artifacts/cellarboss-${RELEASE_TAG}-android.aab" --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
 
   docker-frontend:
     name: Build & Push Frontend Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Check formatting
@@ -36,6 +38,8 @@ jobs:
     needs: [prettier, tests, smoketest-android]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Generate API docs
@@ -56,6 +60,8 @@ jobs:
     needs: [prettier, tests, smoketest-android]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Cache Playwright browsers
@@ -99,6 +105,8 @@ jobs:
     needs: [prettier, tests, smoketest-android]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Setup Java
@@ -268,6 +276,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Setup Java
@@ -345,6 +355,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Download Android AAB
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -377,6 +389,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -420,6 +434,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,6 +359,7 @@ jobs:
     needs: [docker-frontend, docker-backend, build-android]
     permissions:
       contents: write
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+# Default to read-only; jobs that need to write elevate their own permissions.
 permissions:
-  contents: write
-  packages: write
-  pages: write
-  id-token: write
+  contents: read
 
 jobs:
   prettier:
@@ -219,6 +217,10 @@ jobs:
     name: Deploy Documentation
     runs-on: ubuntu-latest
     needs: [build-api-docs, build-webui-user-docs, build-mobile-user-docs]
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -352,6 +354,8 @@ jobs:
     name: Publish GitHub Release
     runs-on: ubuntu-latest
     needs: [docker-frontend, docker-backend, build-android]
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -385,6 +389,9 @@ jobs:
     name: Build & Push Frontend Image
     runs-on: ubuntu-latest
     needs: [prettier, tests, smoketest-android]
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout
@@ -430,6 +437,9 @@ jobs:
     name: Build & Push Backend Image
     runs-on: ubuntu-latest
     needs: [prettier, tests, smoketest-android]
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       - name: Renovate

--- a/.github/workflows/smoketest-android.yml
+++ b/.github/workflows/smoketest-android.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-node
 
       - name: Setup Java

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,26 @@
+# zizmor configuration
+# https://docs.zizmor.sh/configuration/
+#
+# Each ignore below documents a finding we have reviewed and accepted as safe
+# for our setup. Prefer fixing findings (e.g. moving expansions into env vars,
+# scoping permissions per-job) over adding entries here.
+
+rules:
+  dangerous-triggers:
+    ignore:
+      # PR Test Reports uses `workflow_run` deliberately: it is the recommended
+      # secure pattern for posting coverage/Playwright comments on PRs from
+      # forks. It downloads artifacts produced by the untrusted PR run but never
+      # checks out or executes that PR's code.
+      - pr-report.yml
+      # PR Labeler uses `pull_request_target` so release-drafter's autolabeler
+      # gets a write-scoped token on fork PRs. It runs only the release-drafter
+      # actions and never checks out or executes the PR's code.
+      - pr-labeler.yml
+
+  cache-poisoning:
+    ignore:
+      # The Release workflow runs only on `v*.*.*` tags pushed by maintainers,
+      # not on untrusted PRs, so its build-input caches are not a realistic
+      # cache-poisoning vector.
+      - release.yml


### PR DESCRIPTION
## Summary

Security hardening of automated workflows

## Changes

- As suggested in #653  - add `persist-credentials: false` to all workflows using `actions/checkout`
- Move to per-step permissions in `release.yml` rather than global write
- Add `zizmor` for workflow security scanning

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [x] Docs / config only

## Areas affected

- [ ] Backend
- [ ] Web application
- [ ] Android application
- [x] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened CI and release workflow permissions, reducing default access and granting elevated permissions only where needed.
  * Added an automated workflow security scan to PR validation.

* **Bug Fixes**
  * Updated checkout steps across multiple workflows to avoid persisting credentials during runs.

* **Chores**
  * Adjusted workflow setup for formatting, validation, release, Renovate, and Android smoke test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->