### PR TITLE
docs: Potential fix for mobile screenshots not being generated

### DIFF
--- a/apps/mobile/docs/screenshots/flows/auth.yaml
+++ b/apps/mobile/docs/screenshots/flows/auth.yaml
@@ -7,7 +7,7 @@ appId: org.cellarboss.mobile
 
 # Capture the server setup screen
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/auth-setup
+- takeScreenshot: auth-setup
 
 # Connect to server
 - tapOn:
@@ -18,4 +18,4 @@ appId: org.cellarboss.mobile
 - waitForAnimationToEnd
 
 # Capture the login screen
-- takeScreenshot: ${SCREENSHOT_DIR}/auth-login
+- takeScreenshot: auth-login

--- a/apps/mobile/docs/screenshots/flows/bottles.yaml
+++ b/apps/mobile/docs/screenshots/flows/bottles.yaml
@@ -6,12 +6,12 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "cellar-tab"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/bottles-list
+- takeScreenshot: bottles-list
 
 # Tap on first bottle to view detail
 - tapOn: "Château Margaux 2015"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/bottles-detail
+- takeScreenshot: bottles-detail
 
 # Go back to list
 - pressKey: back
@@ -21,7 +21,7 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "fab-add"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/bottles-create
+- takeScreenshot: bottles-create
 
 # Go back
 - pressKey: back
@@ -33,4 +33,4 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "header-action-pencil"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/bottles-edit
+- takeScreenshot: bottles-edit

--- a/apps/mobile/docs/screenshots/flows/dashboard.yaml
+++ b/apps/mobile/docs/screenshots/flows/dashboard.yaml
@@ -4,4 +4,4 @@ appId: org.cellarboss.mobile
 
 # Dashboard is the default tab after login
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/dashboard-overview
+- takeScreenshot: dashboard-overview

--- a/apps/mobile/docs/screenshots/flows/navigation.yaml
+++ b/apps/mobile/docs/screenshots/flows/navigation.yaml
@@ -4,10 +4,10 @@ appId: org.cellarboss.mobile
 
 # Capture tab bar (dashboard is active by default)
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/navigation-tabs
+- takeScreenshot: navigation-tabs
 
 # Navigate to More tab
 - tapOn:
     id: "more-tab"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/navigation-more
+- takeScreenshot: navigation-more

--- a/apps/mobile/docs/screenshots/flows/reference-data.yaml
+++ b/apps/mobile/docs/screenshots/flows/reference-data.yaml
@@ -9,7 +9,7 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "menu-winemakers"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/winemakers-list
+- takeScreenshot: winemakers-list
 
 # --- Regions ---
 - tapOn:
@@ -18,7 +18,7 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "menu-regions"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/regions-list
+- takeScreenshot: regions-list
 
 # --- Countries ---
 - tapOn:
@@ -32,7 +32,7 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "menu-countries"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/countries-list
+- takeScreenshot: countries-list
 
 # --- Grapes ---
 - tapOn:
@@ -41,7 +41,7 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "menu-grapes"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/grapes-list
+- takeScreenshot: grapes-list
 
 # --- Locations ---
 - tapOn:
@@ -55,10 +55,10 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "menu-locations"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/locations-list
+- takeScreenshot: locations-list
 
 # --- Storages (use tab) ---
 - tapOn:
     id: "storages-tab"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/storages-list
+- takeScreenshot: storages-list

--- a/apps/mobile/docs/screenshots/flows/tasting-notes.yaml
+++ b/apps/mobile/docs/screenshots/flows/tasting-notes.yaml
@@ -9,10 +9,10 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "menu-tasting-notes"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/tasting-notes-list
+- takeScreenshot: tasting-notes-list
 
 # Tap FAB to create new tasting note
 - tapOn:
     id: "fab-add"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/tasting-notes-create
+- takeScreenshot: tasting-notes-create

--- a/apps/mobile/docs/screenshots/flows/wines.yaml
+++ b/apps/mobile/docs/screenshots/flows/wines.yaml
@@ -6,12 +6,12 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "wines-tab"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/wines-list
+- takeScreenshot: wines-list
 
 # Tap on first wine to view detail
 - tapOn: "Château Margaux"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/wines-detail
+- takeScreenshot: wines-detail
 
 # Go back to list
 - pressKey: back
@@ -21,4 +21,4 @@ appId: org.cellarboss.mobile
 - tapOn:
     id: "fab-add"
 - waitForAnimationToEnd
-- takeScreenshot: ${SCREENSHOT_DIR}/wines-create
+- takeScreenshot: wines-create

--- a/apps/mobile/docs/screenshots/generate.sh
+++ b/apps/mobile/docs/screenshots/generate.sh
@@ -23,7 +23,7 @@ mkdir -p "$MAESTRO_OUTPUT_DIR"
 # The || captures the exit code so set -e doesn't abort before copying screenshots.
 echo "Running Maestro screenshot flows..."
 cd "$SCRIPT_DIR"
-timeout 900 maestro test --output "$MAESTRO_OUTPUT_DIR" --env SCREENSHOT_DIR="$MAESTRO_OUTPUT_DIR" flows/ || MAESTRO_EXIT_CODE=$?
+timeout 900 maestro test --test-output-dir "$MAESTRO_OUTPUT_DIR" flows/ || MAESTRO_EXIT_CODE=$?
 MAESTRO_EXIT_CODE=${MAESTRO_EXIT_CODE:-0}
 
 # 2. Copy screenshots to docs public directory


### PR DESCRIPTION
## Summary

Potential fix for mobile application screenshots not being generated for documentation

## Changes

- Don't pass a screenshot directory into `maestro`, use the default instead

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Dependency update
- [x] Docs / config only

## Areas affected

- [ ] Backend
- [ ] Web application
- [x] Android application
- [ ] Project scaffolding (Docker images etc)

## Related Issues

<!-- Link any related issues: "Closes #123" or "Related to #456" -->
